### PR TITLE
feat: integrate Claude workflow with project config

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,35 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash(git push*)",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "branch=$(git branch --show-current 2>/dev/null); if [ \"$branch\" = \"main\" ] || [ \"$branch\" = \"master\" ]; then echo '🚫 BLOCKED: Use a feature branch + PR. See /push-changes skill.' >&2; exit 1; fi"
+          }
+        ]
+      },
+      {
+        "matcher": "Bash(git commit*)",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "echo '💡 Reminder: Run security checks before committing (grep for IPs, MACs, emails)' >&2"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Write(*.py)",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "uv run ruff check \"$CLAUDE_FILE_PATH\" --fix --quiet 2>/dev/null || true"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/skills/hvac-status.md
+++ b/.claude/skills/hvac-status.md
@@ -1,0 +1,52 @@
+# HVAC Air Quality System Status Check
+
+Check the health and status of both air quality monitoring systems (Unifi Cloud Gateway and Spark DGX).
+
+## What this skill does
+
+1. **Unifi Cloud Gateway ($GATEWAY_IP or 192.168.X.1)**
+   - Check if cron job exists and is running
+   - Show last collection timestamp from logs
+   - Verify data is being written to Google Sheets
+
+2. **Spark DGX ($DGX_IP or 192.168.X.XXX)**
+   - Check systemd timer status
+   - Show last collection timestamp
+   - Show next scheduled collection time
+   - Verify data collection is working
+
+3. **Data Validation**
+   - Compare timestamps from both systems
+   - Check for data gaps (collections should be ~5 minutes apart)
+   - Alert if either system hasn't collected in >10 minutes
+
+4. **Sensor Status**
+   - Show latest sensor readings from both systems
+   - Compare indoor/outdoor PM2.5 levels
+   - Show filter efficiency calculations
+
+## Commands to run
+
+```bash
+# Check Unifi Gateway (set GATEWAY_IP in environment)
+ssh root@${GATEWAY_IP:-192.168.X.1} "crontab -l | grep collect && tail -30 /data/logs/air_quality.log"
+
+# Check Spark DGX (set DGX_IP and DGX_USER in environment)
+ssh ${DGX_USER:-user}@${DGX_IP:-192.168.X.XXX} "systemctl --user status air-quality-collector.timer && systemctl --user list-timers air-quality-collector.timer && tail -30 ~/hvac-air-quality-analysis/logs/air_quality.log"
+```
+
+## Expected output
+
+Provide a summary showing:
+- ✅/❌ Status of each system
+- ⏰ Last collection time for each
+- 📊 Latest sensor readings
+- ⚠️ Any alerts or issues detected
+- 📈 Trend: Both systems collecting normally / Issues detected
+
+## Success criteria
+
+- Both systems should show collections within last 10 minutes
+- No error messages in logs
+- Data being written to Google Sheets successfully
+- Sensor readings are reasonable (PM2.5 < 100, CO2 < 5000, etc.)

--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ data/
 *.jsonl
 !data/.gitkeep
 !*_template.csv
+!.claude/settings.json
 
 # Logs
 logs/
@@ -66,3 +67,10 @@ Thumbs.db
 dist/
 build/
 *.egg-info/
+
+# Claude Code - local settings (permissions, personal config)
+.claude/settings.local.json
+
+# Claude Code - these SHOULD be committed:
+# .claude/settings.json (project hooks)
+# .claude/skills/ (project-specific skills)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,33 @@
 
 **PURPOSE:** Prevent common mistakes when working with this codebase. Read this FIRST.
 
+## 🚨 CRITICAL: Git Workflow (Feature Branch + PR)
+
+**NEVER push directly to main.** Always use feature branches and PRs.
+
+```bash
+# 1. Create feature branch
+git checkout -b feat/your-feature-name
+
+# 2. Make changes and commit
+# Use /push-changes skill (enforces conventional commits)
+
+# 3. Create PR
+gh pr create
+
+# 4. After review/merge, clean up
+git checkout main && git pull && git branch -d feat/your-feature-name
+```
+
+### Available Skills (user-level)
+| Skill | Purpose |
+|-------|---------|
+| `/push-changes` | Commit with conventional format, blocks main pushes |
+| `/release` | Full release workflow with version bump |
+| `/review-loop` | Iterate on PR review comments |
+| `/pr-comments` | Fetch and categorize PR review comments |
+| `/hvac-status` | Check sensor collection status (project-level) |
+
 ## 🚨 CRITICAL: Release Process (Do This EXACTLY)
 
 ```bash


### PR DESCRIPTION
## Summary

- Add project-level Claude hooks to enforce git workflow
- Move project-specific skill (`hvac-status.md`) from user-level to project-level
- Update CLAUDE.md to reference available user-level skills
- Update .gitignore to commit shared Claude config but ignore local settings

## Changes

### Project Hooks (`.claude/settings.json`)
| Hook | Trigger | Action |
|------|---------|--------|
| PreToolUse | `git push*` | Block pushes to main/master |
| PreToolUse | `git commit*` | Remind about security checks |
| PostToolUse | `Write(*.py)` | Auto-format with ruff |

### CLAUDE.md Updates
- Added git workflow section (feature branch + PR)
- Listed available user-level skills (`/push-changes`, `/release`, etc.)
- Referenced project-level `/hvac-status` skill

### Skill Migration
- Moved `hvac-status.md` from `~/.claude/skills/` to `.claude/skills/`
- Sanitized hardcoded IPs to use environment variables

## Test plan
- [ ] New Claude session picks up project hooks
- [ ] `git push` to main is blocked on feature branch
- [ ] `/hvac-status` skill is available in this project

🤖 Generated with [Claude Code](https://claude.com/claude-code)