### PR TITLE
feat: add Temp Stick attic sensor + docs sync

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,18 +14,14 @@ AIRGRADIENT_SERIAL=your_airgradient_serial_here
 # Indoor AirGradient sensor (for second bedroom)
 AIRGRADIENT_INDOOR_SERIAL=your_airgradient_indoor_serial_here
 
-# Google Forms Configuration
-# Create form and get these from the pre-filled link
-GOOGLE_FORM_ID=your_form_id_here
+# AirGradient sensor IPs (run scripts/update_airgradient_ips.py to discover)
+AIRGRADIENT_OUTDOOR_IP=192.168.X.XX
+AIRGRADIENT_INDOOR_IP=192.168.X.XX
 
-# Form field IDs (inspect form HTML to find these)
-FORM_TIMESTAMP=entry.123456789
-FORM_INDOOR_PM25=entry.234567890
-FORM_OUTDOOR_PM25=entry.345678901
-FORM_EFFICIENCY=entry.456789012
-FORM_INDOOR_CO2=entry.567890123
-FORM_INDOOR_VOC=entry.678901234
-FORM_DAYS_SINCE=entry.789012345
+# Google Sheets API
+# See wiki Software-Setup for full setup instructions
+GOOGLE_SPREADSHEET_ID=your_spreadsheet_id_here
+GOOGLE_SHEET_TAB=Cleaned_Data_20250831
 
 # Temp Stick WiFi sensor (attic temperature/humidity)
 # Get API key from https://tempstickapi.com

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Temp Stick WiFi sensor integration for attic temperature/humidity monitoring
+- `get_tempstick_data()` with graceful failure (optional sensor, silently skipped if not configured)
+- `build_air_quality_row()` and `build_temp_only_row()` helpers to eliminate row construction duplication
+- Project context files: `CLAUDE_CODE_CONTEXT.md` (vision/architecture) and `BACKLOG.md` (prioritized tasks)
+- `.env.example` template for all environment variables
+- 6 new tests for Temp Stick API integration (22 total)
+
+### Changed
+- Fixed ERV model in docs: Panasonic FV-04VE1 → Carrier ERVXXLHB (horizontal, attic-installed)
+- Deduplicated `CLAUDE.md` by removing rules inherited from global config
+
+### Fixed
+- Temp Stick API returns °C natively (not °F as initially assumed) — removed incorrect double conversion
+
 ## [0.5.0] - 2026-01-17
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -192,8 +192,8 @@ When updating `apps_script_code.gs`:
 1. Copy entire file contents
 2. Open Google Sheets → Extensions → Apps Script
 3. Replace all code
-4. Save and test with `testAlert()` function
-5. Check Script Properties has EMAIL_RECIPIENT set
+4. Save and test with `test()` function
+5. Check Script Properties has `ALERT_EMAIL` and `ALERT_EMAIL_2` set
 
 ## HVACMonitor.gs (Google Apps Script)
 
@@ -221,7 +221,7 @@ When updating `apps_script_code.gs`:
 
 4. **Configuration via Script Properties**
    - `LOCATION_LAT`, `LOCATION_LON`, `LOCATION_NAME`, `LOCATION_TIMEZONE`
-   - `EMAIL_RECIPIENT` for alerts
+   - `ALERT_EMAIL` for your alerts, `ALERT_EMAIL_2` for spouse alerts
 
 ### Updating HVACMonitor
 1. Copy contents of `HVACMonitor_v3.gs`
@@ -231,7 +231,8 @@ When updating `apps_script_code.gs`:
 5. Run `calibrateEfficiencyThresholds()` monthly for your data
 
 ### Testing Functions
-- `testEfficiencyCheck()` - Test filter efficiency alerts
+- `test()` - Test all alert checks (efficiency, indoor spike, AQI, pressure, CO2, data gaps, zone filters)
+- `testIndoorSpike()` - Test indoor PM spike detection specifically
 - `analyzeFilterReplacements()` - Compare before/after replacement
 - `analyzeEfficiencyData()` - Validate measurement robustness
 

--- a/CLAUDE_CODE_CONTEXT.md
+++ b/CLAUDE_CODE_CONTEXT.md
@@ -66,11 +66,11 @@ Sensors → Python (DGX Spark) → Google Sheets → Apps Script
 | Component | Model | Purpose |
 |-----------|-------|---------|
 | ERV | Carrier ERVXXLHB | Fresh air + CO2 reduction (horizontal, attic-installed) |
-| Main Filter | Carrier MERV 15 + Plasma | PM2.5 filtration + pathogen killing |
+| Main Filter | MERV 13 | PM2.5 filtration |
 | Heat Pump | [model] | Gentle heating/cooling, no dry air |
 | Zone Filters | 12x12x1 | Individual room blower protection |
 
-## Key Data Findings (82,791 readings)
+## Key Data Findings (93,556 readings)
 
 1. **Filter Life**: MERV 13 maintains >85% efficiency for 120+ days (manufacturer says 45)
 2. **Load-based prediction FAILED**: Filter at 197% of "max life" still performed at 87.3%

--- a/CLAUDE_CODE_CONTEXT.md
+++ b/CLAUDE_CODE_CONTEXT.md
@@ -10,7 +10,7 @@ Transform this data collection project into a family health dashboard that any f
 
 My mother lived next to a freeway for 20 years. The constant coughing. The asthma. The cancer. Her early passing at 67.
 
-My wife has asthma. My son was sick every 45 days. After installing ERV + MERV15 + heat pump and monitoring air quality:
+My wife has asthma. My son was sick every 45 days. After installing ERV + MERV 13 + heat pump and monitoring air quality:
 - CO2 in son's bedroom: 1000+ ppm → 600 ppm
 - Son's sickness: every 45 days → healthy all fall/winter 2025
 - Wife's asthma triggers: reduced
@@ -22,7 +22,7 @@ The research is clear: CO2 above 1000 ppm reduces children's cognitive performan
 ### What Works
 - **Sensors**: Airthings (indoor) + AirGradient (outdoor + second room)
 - **Collection**: Python scripts on DGX Spark, systemd timers, 5-minute intervals
-- **Storage**: Google Sheets (82,791+ readings)
+- **Storage**: Google Sheets (93,556+ readings)
 - **Alerting**: Google Apps Script (HVACMonitor_v3.gs)
   - Efficiency-based filter alerts (not time-based)
   - Seasonal calibration
@@ -72,7 +72,7 @@ Sensors → Python (DGX Spark) → Google Sheets → Apps Script
 
 ## Key Data Findings (93,556 readings)
 
-1. **Filter Life**: MERV 13 maintains >85% efficiency for 120+ days (manufacturer says 45)
+1. **Filter Life**: ERV MERV 13 lasted 151 days (manufacturer says 90)
 2. **Load-based prediction FAILED**: Filter at 197% of "max life" still performed at 87.3%
 3. **Efficiency-based alerts WORK**: Measure actual performance, not theoretical decay
 4. **Seasonal calibration needed**: Winter/summer have different outdoor PM2.5 baselines

--- a/DATA_DICTIONARY.md
+++ b/DATA_DICTIONARY.md
@@ -111,12 +111,11 @@ else:
     efficiency = max(0, min(100, efficiency))  # Clamp 0-100%
 ```
 
-## Alert Thresholds
+## Alert Thresholds (HVACMonitor v3)
 
 ### Filter Efficiency
-- **< 85%**: Warning - Monitor closely
-- **< 80%**: Critical - Plan replacement
-- **< 75%**: Urgent - Replace immediately
+- **< 75%**: Change filter - efficiency declining (default; auto-calibrated monthly)
+- **< 65%**: Critical - filter is failing, replace immediately (default; auto-calibrated monthly)
 
 ### Indoor Air Quality
 - **PM2.5 > 12 μg/m³**: WHO annual guideline exceeded
@@ -124,10 +123,12 @@ else:
 - **CO2 > 1000 ppm**: Ventilation recommended
 - **CO2 > 2000 ppm**: Poor ventilation - immediate action needed
 
-### Smart Alerting (v0.4.0)
-- **High Confidence**: Outdoor PM2.5 > 10 μg/m³ (reliable baseline)
-- **Medium Confidence**: Outdoor PM2.5 5-10 μg/m³
-- **Low Confidence**: Outdoor PM2.5 < 5 μg/m³ (suppressed during activity hours)
+### Seasonal Outdoor PM2.5 Minimums (for reliable efficiency)
+- **Winter (Dec-Feb)**: >= 10 μg/m³ required
+- **Summer (Jun-Aug)**: >= 5 μg/m³ required
+- **Spring/Fall**: >= 7 μg/m³ required
+
+Readings below these thresholds are excluded from efficiency calculations.
 
 ## Data Quality Notes
 
@@ -138,15 +139,16 @@ else:
 
 ## Schema Version
 
-- **Version**: 2.1
-- **Date**: 2025-09-01
+- **Version**: 2.2
+- **Date**: 2026-02-08
+- **Changes in v2.2**: Added Temp Stick sensor type (`tempstick`, room `attic`), updated alert thresholds for HVACMonitor v3
 - **Changes in v2.1**: Added smart alerting thresholds, clarified WHO guidelines
 - **Breaking Change from v1.0**: Added Sensor_ID, Room, Sensor_Type, Indoor_NOX columns (v2.0)
 
 ## Implementation Status
 
-- ✅ Data collection to 18-column schema (v0.4.0)
+- ✅ Data collection to 18-column schema (v0.4.0+)
 - ✅ Multi-room support with sensor identification
-- ✅ Smart alerting with confidence levels
-- ✅ Median-based spike filtering
-- ✅ Activity hour suppression for low-confidence alerts
+- ✅ Temp Stick attic sensor integration (v0.5.0+)
+- ✅ HVACMonitor v3 efficiency-based alerting with seasonal calibration
+- ✅ Median-based efficiency calculation with high-confidence filtering

--- a/analyze_historical.py
+++ b/analyze_historical.py
@@ -194,7 +194,7 @@ def generate_report(df):
 
     # Cost analysis
     print("\n=== Cost Analysis ===")
-    hvac_filter_cost = 130  # MERV 15
+    hvac_filter_cost = 130  # MERV 13
     erv_filter_cost = 50  # MERV 13
 
     days_since_last_change = (datetime.now() - pd.to_datetime(FILTER_UPGRADE)).days


### PR DESCRIPTION
## Summary
- Add Temp Stick WiFi sensor integration for attic temperature/humidity monitoring
- Fix Temp Stick API unit handling (API returns °C, not °F — removed double conversion)
- Correct MERV 15 → MERV 13 in docs to match actual filter spec
- Add project context files (BACKLOG.md, CLAUDE_CODE_CONTEXT.md, .env.example)
- Sync documentation with HVACMonitor v3 and current deployment state

## Why this is blocking
The attic sensor data is only being recorded on this branch. Production on DGX Spark runs `main`, so attic temperature has not been collected since the initial test run. **Every hour without this merge is a missed attic data point.**

## Test plan
- [x] Temp Stick API tested with live sensor (°C confirmed)
- [x] Unit tests added for `get_tempstick_data()` and `build_temp_only_row()`
- [ ] After merge: `git pull` on DGX Spark and verify next collection includes attic row

🤖 Generated with [Claude Code](https://claude.com/claude-code)