### PR TITLE
fix: per-sensor data gap alerts with cooldown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Project context files: `CLAUDE_CODE_CONTEXT.md` (vision/architecture) and `BACKLOG.md` (prioritized tasks)
 - `.env.example` template for all environment variables
 - 6 new tests for Temp Stick API integration (22 total)
+- AI analysis plan for RAPIDS + Ollama GPU-accelerated pipeline (`docs/AI_ANALYSIS_PLAN.md`)
 
 ### Changed
 - Fixed ERV model in docs: Panasonic FV-04VE1 → Carrier ERVXXLHB (horizontal, attic-installed)
@@ -21,6 +22,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Temp Stick API returns °C natively (not °F as initially assumed) — removed incorrect double conversion
+- Data gap alert now checks per-sensor instead of last row — no more false positives when one sensor is down
+- Added cooldown (one alert per gap per sensor) and recovery notification when sensor resumes
 
 ## [0.5.0] - 2026-01-17
 


### PR DESCRIPTION
## Summary
- `checkDataCollection()` now checks each sensor type independently instead of just the last row
- One alert per gap per sensor (no more hourly spam)
- Recovery notification when a sensor comes back online

## Bug
The old code checked only the last row's timestamp. With 3 sensor types writing rows (airthings, airgradient, tempstick), if one sensor dies but others keep writing, the alert never fires. Conversely, during a real gap it fired CRITICAL every hour with no "resumed" follow-up.

## Test plan
- [ ] Copy updated `HVACMonitor_v3.gs` into Google Apps Script
- [ ] Run `test()` to verify `checkDataCollection()` returns per-sensor status
- [ ] Verify Script Properties show `DATA_GAP_<sensorType>` keys during gaps

🤖 Generated with [Claude Code](https://claude.com/claude-code)