### PR TITLE
feat: add headless Sheets → parquet cache refresh utility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
     "pytz>=2025.2",
     "streamlit>=1.41.0",
     "statsmodels>=0.14.4",
+    "pyarrow>=18.0.0",
 ]
 
 [project.scripts]

--- a/scripts/refresh_cache.py
+++ b/scripts/refresh_cache.py
@@ -30,16 +30,32 @@ EXPECTED_COLS = 18
 SHEET_RANGE = "A:R"
 
 NUMERIC_COLS = [
-    "Indoor_PM25", "Outdoor_PM25", "Filter_Efficiency",
-    "Indoor_CO2", "Outdoor_CO2",
-    "Indoor_VOC", "Indoor_NOX", "Indoor_Temp", "Indoor_Humidity", "Indoor_Radon",
-    "Outdoor_Temp", "Outdoor_Humidity", "Outdoor_VOC", "Outdoor_NOX",
+    "Indoor_PM25",
+    "Outdoor_PM25",
+    "Filter_Efficiency",
+    "Indoor_CO2",
+    "Outdoor_CO2",
+    "Indoor_VOC",
+    "Indoor_NOX",
+    "Indoor_Temp",
+    "Indoor_Humidity",
+    "Indoor_Radon",
+    "Outdoor_Temp",
+    "Outdoor_Humidity",
+    "Outdoor_VOC",
+    "Outdoor_NOX",
 ]
 # Columns whose positions shifted when the schema went from 17 to 18 cols.
 # For rows with len(row) < EXPECTED_COLS, these values are unreliable.
 SHIFTED_COLS = [
-    "Indoor_Temp", "Indoor_Humidity", "Indoor_Radon",
-    "Outdoor_CO2", "Outdoor_Temp", "Outdoor_Humidity", "Outdoor_VOC", "Outdoor_NOX",
+    "Indoor_Temp",
+    "Indoor_Humidity",
+    "Indoor_Radon",
+    "Outdoor_CO2",
+    "Outdoor_Temp",
+    "Outdoor_Humidity",
+    "Outdoor_VOC",
+    "Outdoor_NOX",
 ]
 
 
@@ -70,8 +86,7 @@ def fetch_from_sheets() -> pd.DataFrame:
     data_rows = values[1:]
     orig_cols = np.fromiter((len(r) for r in data_rows), dtype=np.int16, count=len(data_rows))
     padded = [
-        row + [""] * (n_cols - len(row)) if len(row) < n_cols else row[:n_cols]
-        for row in data_rows
+        row + [""] * (n_cols - len(row)) if len(row) < n_cols else row[:n_cols] for row in data_rows
     ]
 
     df = pd.DataFrame(padded, columns=headers)

--- a/scripts/refresh_cache.py
+++ b/scripts/refresh_cache.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+# Headless refresh of .cache/air_quality.parquet from Google Sheets.
+# Mirrors scripts/dashboard.py::_fetch_from_sheets + _save_parquet — inlined
+# rather than imported because dashboard.py imports streamlit at module scope.
+# TODO: extract scripts/_sheets_loader.py to dedupe this, dashboard.py, and
+#   bench_heatmap.py (three near-identical copies of the same fetch pipeline).
+# Invoke manually when you want fresh data:  uv run python scripts/refresh_cache.py
+
+import os
+import socket
+import sys
+import time
+from datetime import datetime
+
+socket.setdefaulttimeout(45)
+
+import numpy as np  # noqa: E402
+import pandas as pd  # noqa: E402
+from dotenv import load_dotenv  # noqa: E402
+from google.oauth2 import service_account  # noqa: E402
+from googleapiclient.discovery import build  # noqa: E402
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+PARQUET_CACHE = os.path.join(REPO_ROOT, ".cache", "air_quality.parquet")
+CREDS_PATH = os.path.join(REPO_ROOT, "google-credentials.json")
+
+# Sheet schema: 18 columns (A:R). Pre-Sep 2025 rows had 17 and need the
+# column-shift repair applied via SHIFTED_COLS below.
+EXPECTED_COLS = 18
+SHEET_RANGE = "A:R"
+
+NUMERIC_COLS = [
+    "Indoor_PM25", "Outdoor_PM25", "Filter_Efficiency",
+    "Indoor_CO2", "Outdoor_CO2",
+    "Indoor_VOC", "Indoor_NOX", "Indoor_Temp", "Indoor_Humidity", "Indoor_Radon",
+    "Outdoor_Temp", "Outdoor_Humidity", "Outdoor_VOC", "Outdoor_NOX",
+]
+# Columns whose positions shifted when the schema went from 17 to 18 cols.
+# For rows with len(row) < EXPECTED_COLS, these values are unreliable.
+SHIFTED_COLS = [
+    "Indoor_Temp", "Indoor_Humidity", "Indoor_Radon",
+    "Outdoor_CO2", "Outdoor_Temp", "Outdoor_Humidity", "Outdoor_VOC", "Outdoor_NOX",
+]
+
+
+def fetch_from_sheets() -> pd.DataFrame:
+    load_dotenv(os.path.join(REPO_ROOT, ".env"))
+    spreadsheet_id = os.getenv("GOOGLE_SPREADSHEET_ID")
+    sheet_tab = os.getenv("GOOGLE_SHEET_TAB", "")
+    if not spreadsheet_id:
+        raise RuntimeError("GOOGLE_SPREADSHEET_ID missing from .env")
+
+    credentials = service_account.Credentials.from_service_account_file(
+        CREDS_PATH, scopes=["https://www.googleapis.com/auth/spreadsheets.readonly"]
+    )
+    service = build("sheets", "v4", credentials=credentials, cache_discovery=False)
+    range_name = f"{sheet_tab}!{SHEET_RANGE}" if sheet_tab else SHEET_RANGE
+    result = (
+        service.spreadsheets()
+        .values()
+        .get(spreadsheetId=spreadsheet_id, range=range_name)
+        .execute()
+    )
+    values = result.get("values", [])
+    if not values:
+        raise RuntimeError("Sheet returned no rows")
+
+    headers = values[0]
+    n_cols = len(headers)
+    data_rows = values[1:]
+    orig_cols = np.fromiter((len(r) for r in data_rows), dtype=np.int16, count=len(data_rows))
+    padded = [
+        row + [""] * (n_cols - len(row)) if len(row) < n_cols else row[:n_cols]
+        for row in data_rows
+    ]
+
+    df = pd.DataFrame(padded, columns=headers)
+    df["Timestamp"] = pd.to_datetime(df["Timestamp"], errors="coerce")
+
+    for col in set(NUMERIC_COLS) & set(df.columns):
+        df[col] = pd.to_numeric(df[col], errors="coerce")
+
+    shifted = orig_cols < EXPECTED_COLS
+    for col in set(SHIFTED_COLS) & set(df.columns):
+        df.loc[shifted, col] = np.nan
+
+    return df.dropna(subset=["Timestamp"]).sort_values("Timestamp").reset_index(drop=True)
+
+
+def main() -> int:
+    stamp = datetime.now().isoformat(timespec="seconds")
+    t0 = time.perf_counter()
+    try:
+        df = fetch_from_sheets()
+        os.makedirs(os.path.dirname(PARQUET_CACHE), exist_ok=True)
+        df.to_parquet(PARQUET_CACHE)
+        dt = time.perf_counter() - t0
+        print(
+            f"[{stamp}] ok rows={len(df)} "
+            f"range={df['Timestamp'].min()}..{df['Timestamp'].max()} elapsed={dt:.1f}s"
+        )
+        return 0
+    except Exception as e:
+        dt = time.perf_counter() - t0
+        print(f"[{stamp}] FAIL elapsed={dt:.1f}s error={type(e).__name__}: {e}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.12"
 resolution-markers = [
     "python_full_version >= '3.14'",

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.12"
 resolution-markers = [
     "python_full_version >= '3.14'",
@@ -717,6 +717,7 @@ dependencies = [
     { name = "numpy" },
     { name = "pandas" },
     { name = "plotly" },
+    { name = "pyarrow" },
     { name = "python-dotenv" },
     { name = "pytz" },
     { name = "requests" },
@@ -748,6 +749,7 @@ requires-dist = [
     { name = "numpy", specifier = ">=2.1.3" },
     { name = "pandas", specifier = ">=2.2.3" },
     { name = "plotly", specifier = ">=5.24.1" },
+    { name = "pyarrow", specifier = ">=18.0.0" },
     { name = "python-dotenv", specifier = ">=1.0.1" },
     { name = "pytz", specifier = ">=2025.2" },
     { name = "requests", specifier = ">=2.32.3" },


### PR DESCRIPTION
## Summary
- New `scripts/refresh_cache.py` — standalone, streamlit-free script that pulls the Google Sheet into `.cache/air_quality.parquet`. Invoke: `uv run python scripts/refresh_cache.py`.
- Adds `pyarrow>=18.0.0` — previously undeclared but implicitly required by `dashboard.py`'s `to_parquet()` call; any clean install would have failed on first cache save.

## Why
Enables on-demand cache refresh for analysis sessions without spinning up Streamlit. Dashboard keeps its own self-refresh logic (1h TTL + Sheets fallback at `dashboard.py:119`).

## Known followup
`dashboard.py:51-110`, `bench_heatmap.py:23-82`, and this file are now three near-identical copies of the same fetch pipeline. TODO comment in the header points at a separate PR to extract `scripts/_sheets_loader.py`. Not in scope for this PR.

## Test plan
- [x] `uv run ruff check scripts/refresh_cache.py` — clean
- [x] Smoke: fetches 142,406 rows in ~5s, writes parquet, exit 0
- [x] `uv sync` installs pyarrow cleanly