### PR TITLE
fix(collector): set descriptive User-Agent on Temp Stick API

### DIFF
--- a/collect_with_sheets_api_v2.py
+++ b/collect_with_sheets_api_v2.py
@@ -315,7 +315,14 @@ def get_tempstick_data():
     try:
         response = requests.get(
             f"https://tempstickapi.com/api/v1/sensor/{TEMP_STICK_SENSOR_ID}",
-            headers={"X-API-KEY": TEMP_STICK_API_KEY},
+            headers={
+                "X-API-KEY": TEMP_STICK_API_KEY,
+                # The edge WAF started 429-ing the default python-requests UA on
+                # 2026-04-13, silently dropping attic data. A descriptive UA
+                # passes the filter. Don't fake a browser UA — honest
+                # identification is fine and works.
+                "User-Agent": "hvac-air-quality-analysis/0.4 (+https://github.com/minghsuy/hvac-air-quality-analysis)",
+            },
             timeout=10,
         )
 


### PR DESCRIPTION
## Summary

One-line fix. The Temp Stick API's edge (likely Cloudflare) started returning **429 Too Many Requests** to the default `python-requests/2.32.5` User-Agent on ~2026-04-13, silently dropping attic sensor data for 3+ days. A descriptive UA passes the filter.

## Evidence

Verified on DGX via direct probe:

| User-Agent | Status | Result |
|---|---|---|
| `python-requests/2.32.5` (default) | 429 | `text/html` "Too Many Requests" body, no `Retry-After` |
| `hvac-air-quality-analysis/0.4 (+https://github.com/…)` | 200 | Live sensor data: `last_temp=20.06`, `last_checkin=4 min ago`, `battery_pct=100`, `offline=0` |

Also confirmed:
- All endpoints 429 (not just `/sensor/{id}` — `/sensors` list too) → not per-endpoint rate-limit
- Laptop IP (no key) → 406, not 429 → block is correlated with UA + IP combination, most likely UA-only
- Sensor itself is healthy; still reports to the Temp Stick cloud (user confirmed via iPhone app)

## Why descriptive over browser-fake

Honest identification (`hvac-air-quality-analysis/0.4 (+repo URL)`) is both ethical and effective. The WAF rule is blocking generic `python-requests` as a bot heuristic, not whitelisting browsers specifically.

## Not fixed here (separate issue to file)

`HVACMonitor_v3.gs::checkDataCollection()` failed to alert on a 3-day attic silence. Root cause: it scans the last 50 rows only, which works out to ~83 minutes of data at current write rates — narrower than the `DATA_GAP_HOURS: 2` threshold, so a stopped sensor falls out of the scan window before becoming stale by the check's standard. Will file as a P1 bug.

## Test plan

- [x] `ruff check` / `ruff format --check` clean
- [x] Live-probe the patched request from DGX → 200 with fresh sensor data
- [ ] After merge, `git pull` on DGX; next 5-min collector tick should start writing attic rows again. Verify with `journalctl --user -u air-quality-collector.service --since '10 minutes ago'` or check the Sheet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)