### PR TITLE
Phase 1a: extract _sheets_loader + fix #28 shift-repair date gate

### DIFF
--- a/docs/plans/2026-04-17-001-fix-monitoring-sprint-plan.md
+++ b/docs/plans/2026-04-17-001-fix-monitoring-sprint-plan.md
@@ -1,0 +1,573 @@
+---
+title: Monitoring sprint — extract shared loader, dedup collector, fix alerts
+type: fix
+status: active
+date: 2026-04-17
+deepened: 2026-04-17
+origin:
+  - https://github.com/minghsuy/hvac-air-quality-analysis/issues/25
+  - https://github.com/minghsuy/hvac-air-quality-analysis/issues/26
+  - https://github.com/minghsuy/hvac-air-quality-analysis/issues/27
+  - https://github.com/minghsuy/hvac-air-quality-analysis/issues/28
+---
+
+# Monitoring sprint — extract shared loader, dedup collector, fix alerts
+
+## Overview
+
+A diagnostic pass triggered by the user reporting a missed alert on 2026-04-16 surfaced four connected issues across the monitoring stack: two Python data-pipeline bugs (collector polling redundancy, parquet shift-repair clobbering Temp Stick rows) and two Apps Script alerting bugs (data-gap detection window too narrow, no absolute indoor-PM alert). This sprint closes all four in three focused PRs, landing Phase 1 (pure Python, low risk) before the `wife-surgery` hard cap in ~2 weeks and Phase 2 (Apps Script deploy) in the same window.
+
+## Problem Frame
+
+Four open issues:
+
+- **#25 (P1 bug)** — `HVACMonitor_v3.gs::checkDataCollection()` scans only last 50 rows, narrower than the 2-hour `DATA_GAP_HOURS` threshold. A stopped sensor falls out of the scan window before becoming stale, so alerts never fire. This bug hid the attic Temp Stick outage for 3+ days.
+- **#26 (P2 enhancement)** — Collector polls Temp Stick every 5 min, but the sensor only updates hourly (battery conservation). 11 of every 12 attic rows are identical duplicates. Cosmetic today, but wastes API calls (risking future WAF re-block) and masks the Sheet's true per-sensor cadence.
+- **#27 (P1 bug)** — No alert fires when indoor PM is elevated (3-5 µg/m³ for 6 hours yesterday) if the delta to outdoor is small and outdoor is mildly polluted. The scenario falls in a blind spot between `checkIndoorSpike` (requires +5 delta) and `checkEfficiency` (requires outdoor ≥ 7 µg/m³).
+- **#28 (P1 bug)** — `refresh_cache.py` and `dashboard.py` apply a "column-shift repair" to any row with <18 columns. Meant for pre-Sep 2025 legacy rows, but also triggers on modern Temp Stick rows that Sheets trims for trailing empties. Result: every attic temp/humidity value has been NaN'd in parquet since Feb 2026 (~15k rows silently wrong).
+
+These four issues share one thread: the multi-sensor, multi-cadence architecture has gaps at every layer — collector writes redundantly, loader clobbers honest cadence variation, monitor assumes uniform rates, alerts assume uniform signals. Fixing all four together restores coherence.
+
+## Requirements Trace
+
+From the four origin issues:
+
+- **R1 (#28)**: Historical attic temp/humidity must become visible in parquet after the fix (retroactive recovery of 15k+ rows by re-reading the Sheet).
+- **R2 (#28)**: Pre-Sep 2025 rows with <18 columns must still receive the shift repair (don't regress the legitimate case).
+- **R3 (#28)**: The three copies of sheets-fetch logic (`refresh_cache.py`, `dashboard.py`, `bench_heatmap.py`) must share a single implementation.
+- **R4 (#26)**: Collector must skip the Sheet write when Temp Stick's `last_checkin` hasn't changed since the last successful write.
+- **R5 (#26)**: After 24 hours of operation, attic row count should be 20-30/day (not 288/day).
+- **R6 (#25)**: A sensor that stops writing must be alerted within `maxGapHours + 1 trigger tick`. Triggers are hourly, so the actual max is `maxGapHours + 1h`: ≤ 4h for Temp Stick (1h cadence, `maxGapHours = 3`), ≤ 2h for Airthings/AirGradient (5-min cadence, `maxGapHours = 1`).
+- **R7 (#25)**: An hourly-cadence sensor (Temp Stick) must not false-alert on normal late check-ins.
+- **R8 (#27)**: Using Apr 16 hourly data as historical replay, a new absolute-threshold alert must fire WARNING between 18:15-18:45.
+- **R9 (#27)**: The new check must not false-alert on Apr 15 (outdoor similar, indoor stayed at 0).
+- **R10 (all)**: Preserves existing behavior that is intentional — `test()` function as Apps Script verification harness, seasonal efficiency `minOutdoorPM` gate, "alert once per gap" script-property semantics.
+
+## Scope Boundaries
+
+- **No changes to collector's core API-fetch logic** — #24 (UA header) already landed; nothing else about the HTTP call changes.
+- **No changes to `HVACMonitor_v3.gs`'s pressure, AQI, CO2, efficiency, or zone-filter checks** — they work correctly for their intended scenarios.
+- **No changes to the 18-column Sheet schema** — the repair stays in place for legacy rows; only the gating changes.
+- **No changes to `pyproject.toml`, `systemd/`, or the DGX deployment path** — collector stays at repo root per #23 plan's hard constraint.
+
+### Deferred to Separate Tasks
+
+- **Dashboard UI changes** to visualize the new `checkIndoorBaseline` alert history: separate post-surgery work.
+- **Adaptive baseline** (rolling 30-day median instead of hardcoded 3 µg/m³ threshold): Phase 2b enhancement; ship the simpler fixed-threshold version first per #27.
+- The alert body for `checkIndoorBaseline` IS in scope (see Unit 10 Approach). The `sendAlerts` wiring is reused as-is.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- **`scripts/refresh_cache.py:62-102`** — primary fetch function; has explicit `SHIFTED_COLS` list and `EXPECTED_COLS=18`. Inlined comment already flags the TODO: *"extract scripts/_sheets_loader.py to dedupe this, dashboard.py, and bench_heatmap.py (three near-identical copies of the same fetch pipeline)."*
+- **`scripts/dashboard.py:60-110`** — parallel copy under a streamlit `@st.cache_data` decorator. Imports streamlit at module scope, which is why the extraction was deferred originally.
+- **`scripts/bench_heatmap.py:23-95`** — third copy; drops the `_orig_cols` column before returning. Less recently touched.
+- **`collect_with_sheets_api_v2.py:310-346`** — `get_tempstick_data()`; was updated for the UA header in #24 commit `4e27780`. Next change (dedup) should preserve the structured return shape so `build_temp_only_row()` at line 388 continues to work.
+- **`HVACMonitor_v3.gs:36-100`** — `CONFIG` dict; hierarchical sensor/threshold structure. New `INDOOR_BASELINE` config and `EXPECTED_SENSORS` dict fit here.
+- **`HVACMonitor_v3.gs:664-728`** — `checkDataCollection()`; the 50-row window bug lives here. `checkIndoorSpike` at 476-538 is the pattern to mirror for the new `checkIndoorBaseline`.
+- **`HVACMonitor_v3.gs:127-183`** — `runAllChecks()`; the wiring point for the new check.
+- **`HVACMonitor_v3.gs` test/calibration functions at 1509+** — pattern for adding new `test()` assertions.
+- **`scripts/hooks/pre-push`** — enforces `ruff check` + `ruff format --check` + secrets scan + root-junk guard. All three Python PRs must pass this.
+- **`tests/test_collect_air_quality.py`** — existing pytest target; new dedup logic needs at least one unit test here.
+
+### Institutional Learnings
+
+- **From the #24 session** (`docs/LESSONS_LEARNED.md`-worthy): WAFs silently dropping default `python-requests` UAs cost 3 days of data loss. Collector changes should now include a User-Agent audit any time new endpoints are added.
+- **From the #28 discovery (this session)**: "column-shift repair" has been silently zeroing attic values for 3+ months. Lesson: data-repair logic that operates on all rows must have timestamp gates or explicit boundary conditions. When a repair targets a historical schema change, encode the cutoff date in the code, not in the comment.
+- **From #23 (tidy-pass)**: collector's absolute path is pinned in DGX systemd. The Phase 1 PRs must not touch the collector's filename or entrypoint.
+- **Apps Script testability** (from earlier sessions): copy-paste deployment means unit tests can't assert in the normal CI sense. The `test()` function is the harness; every new check needs a matching test-function branch.
+
+### External References
+
+Not needed — all four issues have concrete, locally-grounded fixes. The Temp Stick API surface is already characterized from #24 (`last_checkin`, `last_temp`, `last_humidity`, `battery_pct`, `offline` fields). Apps Script API semantics are well-documented in the existing HVACMonitor_v3.gs.
+
+## Key Technical Decisions
+
+| Decision | Rationale |
+|---|---|
+| Extract to `scripts/_sheets_loader.py` (leading underscore) and import as `from _sheets_loader import ...` | Scripts invoked via `python scripts/foo.py` or `streamlit run scripts/foo.py` get `scripts/` as `sys.path[0]`, so `_sheets_loader` is directly importable as a sibling module — no `scripts.` prefix, no `__init__.py`, no sys.path manipulation. Leading underscore signals private/internal module. Root-level placement is blocked by PR #23's root-junk guard. |
+| Gate shift-repair with `Timestamp < pd.Timestamp("2025-09-01")` | The schema stabilized Sep 2025 (verified: last 17-col master_bedroom rows in Aug 2025). Timestamp-based gate is correct; row-length alone is too loose. |
+| Keep dedup state in `.cache/tempstick_last_checkin` (flat file) | `.cache/` already gitignored; plain-text file is trivially inspectable and portable; avoids introducing a new SQLite or database dependency. |
+| Dedup: skip entire `build_temp_only_row` call when `last_checkin` unchanged | Cleaner than writing a "null row" — the Sheet reflects true cadence. Matches #25's new monitor which scans by timestamp, not row count. |
+| `EXPECTED_SENSORS` as dict with per-sensor `maxGapHours`, not a flat list | Allows 1h cadence (Temp Stick) to coexist with 5-min cadence (Airthings/AirGradient) without false-alerting. Directly addresses #25 Bug 2. |
+| Scan window = `max(maxGapHours) × 2` hours, not 50 rows | Decouples scan size from write rate. After #26 dedup cuts Temp Stick to 24/day, row-based scanning would break. |
+| `checkIndoorBaseline` uses fixed threshold `3 µg/m³` sustained 30 min, not rolling baseline | Per #27 acceptance criterion — simpler, ships today. Rolling baseline is deferred enhancement. Threshold chosen because master-bedroom baseline is effectively 0 (Airthings rounds to int). |
+| Include directional context in #27 alert body (indoor vs outdoor) | Adds diagnostic value without more thresholds: "indoor > outdoor" suggests filtration failure; "indoor < outdoor" suggests infiltration overwhelming filter. |
+| Three small PRs, not one | Matches prior sprint discipline (#23 had one commit per unit, clean reverts). Each PR shippable independently; reviewer can land Phase 1 while Phase 2 is drafted. |
+| Phase 2 bundles #25 and #27 in one Apps Script commit | Both modify `HVACMonitor_v3.gs` and share `EXPECTED_SENSORS` / `CONFIG` expansion. Deployment is copy-paste — bundling saves one deploy cycle. |
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Should `_sheets_loader.py` be under `scripts/` or a new `src/`?** → Under `scripts/`. Project has no `src/` convention (CLAUDE.md: "flat structure required"), and the tidy-pass in #23 established `scripts/utils/` / `scripts/collectors/` / `scripts/analysis/` as the nesting pattern. `scripts/_sheets_loader.py` at the scripts root makes it a peer of the 3 callers.
+- **Should the cache file survive across collector upgrades?** → Yes. The cache is content-addressed by `last_checkin`, which never regresses. No migration concerns.
+- **Should `checkIndoorBaseline` fire CRITICAL, WARNING, or INFO?** → WARNING. CRITICAL is reserved for filter-failing and sensor-stopped alerts. This is "something is elevated, investigate" — WARNING matches the severity.
+- **Should the new check run in the wife's alert stream too (`ALERT_EMAIL_2`)?** → No. It's a household-health signal, not a pressure/nerve-pain signal. Goes to `ALERT_EMAIL` only.
+- **Do we need to migrate historical duplicate tempstick rows once #26 ships?** → No. Duplicates in the Sheet are harmless (medians unaffected). Forward dedup is sufficient.
+
+### Deferred to Implementation
+
+- **Exact pytest fixture shape for dedup testing** — the test needs to simulate two `get_tempstick_data()` calls with same `last_checkin`; leave fixture design to the implementer but confirm second call returns `None`.
+- **Apps Script test-function wiring** — read against the live Sheet, not synthetic injection (see Unit 11).
+- **Whether Apps Script deploy happens in-session or deferred** — user-side decision. Plan treats the deploy step as user-driven.
+
+### Locked-in decisions (user approved 2026-04-17)
+
+- **Backtest before Phase 2**: yes. A new Unit 7.5 runs `P(30-min rolling median of master_bedroom Indoor_PM25 > 3)` across the 9-month parquet before Phase 2 commits. If base rate >1-2 events/week, tune threshold before merging.
+- **bench_heatmap.py**: migrate (not delete).
+- **Phase 2 bundling**: #25 and #27 ship together in PR 3.
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.*
+
+Three isolated change surfaces, executed in dependency order:
+
+```
+PR 1 — Phase 1a  (Python, code-only)
+┌──────────────────────────────────────────────────────────────────┐
+│  scripts/_sheets_loader.py  (NEW)                                │
+│    ├── load_sheet_as_df(sheet_tab, creds_path, spreadsheet_id)   │
+│    │     └── applies SHIFTED_COLS repair ONLY when               │
+│    │         Timestamp < SCHEMA_STABILIZED                       │
+│    └── CONSTANTS: EXPECTED_COLS, SHIFTED_COLS, NUMERIC_COLS,     │
+│                   SCHEMA_STABILIZED                              │
+│                                                                  │
+│  3 callers migrate to the shared loader:                         │
+│    scripts/refresh_cache.py  ──┐                                 │
+│    scripts/dashboard.py      ──┼──> from scripts._sheets_loader  │
+│    scripts/bench_heatmap.py  ──┘      import load_sheet_as_df    │
+└──────────────────────────────────────────────────────────────────┘
+          │
+          ▼  (merge, pull to DGX, verify historical attic in parquet)
+          │
+PR 2 — Phase 1b  (collector, code-only)
+┌──────────────────────────────────────────────────────────────────┐
+│  collect_with_sheets_api_v2.py::get_tempstick_data                │
+│    state: .cache/tempstick_last_checkin (gitignored flat file)   │
+│    logic: if response last_checkin == cached → return None       │
+│           else → write new cache, return dict (current behavior) │
+│                                                                  │
+│  tests/test_collect_air_quality.py                                │
+│    test_dedup_skips_unchanged_checkin                             │
+└──────────────────────────────────────────────────────────────────┘
+          │
+          ▼  (merge, pull to DGX, observe 24h: attic ≤ 30 rows/day)
+          │
+PR 3 — Phase 2  (Apps Script, bundled)
+┌──────────────────────────────────────────────────────────────────┐
+│  HVACMonitor_v3.gs                                                │
+│    CONFIG {                                                       │
+│      EXPECTED_SENSORS: {                                          │
+│        airthings:   { maxGapHours: 1 },                           │
+│        airgradient: { maxGapHours: 1 },                           │
+│        tempstick:   { maxGapHours: 3 },                           │
+│      },                                                           │
+│      INDOOR_BASELINE: {                                           │
+│        absoluteThreshold: 3,                                      │
+│        sustainedMinutes: 30,                                      │
+│        cooldownMinutes: 60,                                       │
+│      },                                                           │
+│    }                                                              │
+│                                                                   │
+│    checkDataCollection():  rewrite to time-window scan            │
+│      scan rows where Timestamp >= now - max(maxGapHours)*2        │
+│      iterate EXPECTED_SENSORS (dict, not lastSeen keys)           │
+│      flag as stopped if !lastSeen[type] OR hoursSince > spec      │
+│                                                                   │
+│    checkIndoorBaseline():  NEW                                    │
+│      filter rows where room == 'master_bedroom' (NOT mirror       │
+│        checkIndoorSpike which doesn't filter by room)             │
+│      take last 6 filtered rows; skip if < 4 (sensor gap)          │
+│      if median(indoor) > absoluteThreshold and not in cooldown:   │
+│        alert WARNING with indoor/outdoor directional context      │
+│                                                                   │
+│    MONITOR_VERSION constant — logged per runAllChecks()           │
+│    runAllChecks():  wire checkIndoorBaseline in                   │
+│    test():  gap + baseline assertions against live Sheet          │
+└──────────────────────────────────────────────────────────────────┘
+          │
+          ▼  (user copy-pastes to Apps Script editor, runs test(), saves)
+```
+
+**Commit ordering matters**: Phase 1a must land before Phase 1b so the monitor (Phase 2, using the Sheet directly) and the analysis layer (parquet, via Phase 1a) both see honest per-sensor cadence when dedup ships in Phase 1b.
+
+## Implementation Units
+
+### Phase 1a — PR 1: Shared loader + #28 fix
+
+- [ ] **Unit 1: Create `scripts/_sheets_loader.py`**
+
+**Goal:** Single source of truth for Sheets → DataFrame conversion with correct shift-repair gating.
+
+**Requirements:** R1, R2, R3
+
+**Dependencies:** None
+
+**Files:**
+- Create: `scripts/_sheets_loader.py`
+- Test: add `TestSheetsLoader` class to existing `tests/test_collect_air_quality.py` — don't create a new test file (the single-file convention matches the repo's pattern).
+
+**Approach:**
+- Expose `load_sheet_as_df(spreadsheet_id, sheet_tab, creds_path) -> pd.DataFrame`.
+- Factor into `_fetch_values(...)` (API call, returns `list[list[str]]`) and `_values_to_df(values)` (pure transform). This gives a clean mock boundary — tests can call `_values_to_df` directly with synthetic row lists, no API mocking chain needed.
+- Export constants: `EXPECTED_COLS = 18`, `SHIFTED_COLS` (the 8-column list), `NUMERIC_COLS`, `SCHEMA_STABILIZED = pd.Timestamp("2025-09-01")`.
+- Apply shift-repair: `shifted = (orig_cols < EXPECTED_COLS) & (df["Timestamp"] < SCHEMA_STABILIZED)`.
+- Do not bake in `.env` loading — each caller loads its own (`refresh_cache.py` uses explicit path, `dashboard.py` uses default). Loader takes parameters, doesn't read env.
+- Drop `_orig_cols` before returning (all 3 callers drop it; no one needs it externally).
+
+**Patterns to follow:**
+- `scripts/refresh_cache.py:62-102` is the reference implementation; it's the most recently touched and has the clearest structure.
+
+**Test scenarios:**
+- Happy path: 3 synthetic rows, 2 modern (18-col, varied content) + 1 Sep 2025 row → all three return with correct numeric columns, no values nulled.
+- Edge case: row with timestamp `2025-08-15`, 17 columns → `Indoor_Temp` is NaN (legacy shift-repair applies).
+- Edge case: row with timestamp `2026-02-10`, 12 columns (Temp Stick pattern) → `Indoor_Temp` preserved (modern schema).
+- Edge case: header mismatch (sheet returns 17 col headers instead of 18) → gracefully pad or surface error.
+- Error path: empty Sheet response → raises `RuntimeError` with clear message.
+
+**Verification:**
+- `uv run pytest tests/test_collect_air_quality.py -v` passes (existing 22 + new `TestSheetsLoader` scenarios).
+- `ruff check` + `ruff format --check` clean on the new module.
+
+- [ ] **Unit 2: Migrate `scripts/refresh_cache.py` to use the shared loader**
+
+**Goal:** Replace the inlined fetch with a one-line import.
+
+**Requirements:** R1, R3
+
+**Dependencies:** Unit 1
+
+**Files:**
+- Modify: `scripts/refresh_cache.py`
+
+**Approach:**
+- Delete the inlined `fetch_from_sheets` body (lines 62-102); replace with a call to `scripts._sheets_loader.load_sheet_as_df`.
+- Keep `scripts/refresh_cache.py`'s own env loading and path setup — the loader doesn't own those.
+- Remove the `TODO` comment about extraction (lines 5-6) — it's now done.
+
+**Patterns to follow:**
+- Keep the script's CLI entry point (`main()` + exit codes) unchanged. Only the fetch body shrinks.
+
+**Test scenarios:**
+- Happy path: run `uv run python scripts/refresh_cache.py` against live Sheet → parquet rebuild succeeds, row count matches prior run.
+- Integration: `df[df['Room']=='attic'].Indoor_Temp.notna().any()` is True on a row after 2026-02-01 (#28 retroactive fix).
+
+**Verification:**
+- Manual run produces parquet; running `parse last_seen per room` query shows attic with non-NaN temp.
+
+- [ ] **Unit 3: Migrate `scripts/dashboard.py` to use the shared loader**
+
+**Goal:** Same replacement in the streamlit dashboard's fetch path.
+
+**Requirements:** R3
+
+**Dependencies:** Unit 1
+
+**Files:**
+- Modify: `scripts/dashboard.py`
+
+**Approach:**
+- Replace the `_fetch_from_sheets` body (lines 60-110). The streamlit `@st.cache_data` decorator stays on the wrapper; only the inner fetch goes to the shared loader.
+- Preserve the `_save_parquet` helper and the `load_raw(force_refresh=...)` wrapping logic. The loader is a pure function; caching stays where it is.
+
+**Patterns to follow:**
+- Leave `dashboard.py`'s streamlit imports untouched — module-scope `import streamlit` is why the loader had to be a separate file in the first place.
+
+**Test scenarios:**
+- Integration: `streamlit run scripts/dashboard.py` — dashboard loads without error, attic charts render temp/humidity (they currently render NaN).
+- Edge case: force-refresh (cache miss) → same code path executes; parquet writes correctly.
+
+**Verification:**
+- Dashboard loads; attic page shows non-NaN values.
+
+- [ ] **Unit 4: Migrate `scripts/bench_heatmap.py` to use the shared loader**
+
+**Goal:** Same replacement in the benchmark script.
+
+**Requirements:** R3
+
+**Dependencies:** Unit 1
+
+**Files:**
+- Modify: `scripts/bench_heatmap.py`
+
+**Approach:**
+- Replace the `fetch_from_sheets` body (lines 23-95). Preserve the benchmark's timing harness and CLI.
+- **Full Phase 1a verification + PR lands in this unit** (collapsed from the old orchestration-only Unit 5):
+  - `uv run ruff check .` + `uv run ruff format --check .` → clean.
+  - `uv run pytest -q` → all 22+ existing + new `TestSheetsLoader` scenarios pass.
+  - Manually run `scripts/refresh_cache.py` → parquet rebuilds. Query: `df[(df.Room=='attic') & (df.Indoor_Temp.notna())].shape[0]` should be >> 0 (before fix: 0).
+  - **Pre-fix diagnostic** (adversarial F3): before rebuilding parquet, query the *old* cache: `df_pre[(df_pre.Timestamp >= '2025-09-01') & (df_pre._orig_cols < 18)].groupby('Sensor_Type').size()`. If any sensor_type besides `tempstick` shows up, investigate before shipping — the cutoff may not be clean.
+  - Spot-check: at least one post-Feb-2026 attic row's `Indoor_Temp` value is within expected attic-temperature range (e.g., 10-40°C).
+  - `rm .cache/air_quality.parquet` before final verification run so streamlit cache-key changes on next dashboard load (documents the fact that the fix requires a cache blow-away, not just a code revert).
+  - Commit as `refactor: extract scripts/_sheets_loader.py and fix shift-repair date gate (#28)`.
+  - Open PR 1 targeting `main`. Body references #28, notes retroactive historical data recovery + pre-fix diagnostic result.
+
+**Patterns to follow:**
+- Same as Unit 2.
+
+**Test scenarios:**
+- Happy path: `uv run python scripts/bench_heatmap.py` runs end-to-end; timing output shows ballpark-same numbers as pre-refactor.
+
+**Verification:**
+- PR 1 open, `mergeable: MERGEABLE`, CI green.
+- Pre-fix diagnostic confirms only `tempstick` rows had shifted false positives post-Sep-2025 (if other sensors appear, block the PR and investigate).
+
+### Phase 1b — PR 2: Collector dedup (#26)
+
+- [ ] **Unit 6: Add `last_checkin` dedup to `get_tempstick_data`**
+
+**Goal:** Skip Sheet writes when Temp Stick has no new reading since last successful fetch.
+
+**Requirements:** R4, R5
+
+**Dependencies:** Phase 1a merged (so historical verification works against a clean parquet)
+
+**Files:**
+- Modify: `collect_with_sheets_api_v2.py` — `get_tempstick_data()` function, ~line 310.
+- Modify: `tests/test_collect_air_quality.py` — add `test_dedup_skips_unchanged_checkin`.
+- Optional: `.gitignore` — already covers `.cache/`, but confirm `.cache/tempstick_last_checkin` is not accidentally re-exposed.
+
+**Approach:**
+- Read the API response as today; extract `checkin = data.get("last_checkin")`.
+- Before returning the dict, compare `checkin` against `.cache/tempstick_last_checkin` file contents. If equal → return `None` (caller skips write).
+- If different: write `checkin` to the cache file **atomically** via `.tmp` + `os.replace` to prevent torn writes on SIGTERM during systemd shutdown.
+- If `last_checkin` field is missing from the 200 response (API schema drift): still return the dict, but **do NOT touch the cache file**. This prevents empty-string state that would starve all subsequent calls.
+- If cache write itself fails (disk full, permission denied): log a warning to stderr + return the dict anyway. Better to have occasional duplicate rows than silently drop readings.
+- **Observability**: emit a stderr warning line if the cache has been unreadable for more than one consecutive invocation — otherwise a broken dedup is invisible until the user notices the row count hasn't dropped. Track this via a small counter in a sibling file (`.cache/tempstick_dedup_health`) or simply log every cache-read failure with a clear tag that `grep`-able from the collector log.
+- Keep other error paths unchanged: 429, `requests.RequestException`, non-200 → `return None` (already the case).
+- Preserve the UA header and request structure from #24.
+
+**Execution note:** Write the failing pytest first (given a fresh cache directory, call `get_tempstick_data` twice with same `last_checkin` → second call returns `None`), then implement.
+
+**Patterns to follow:**
+- Read/write state to `.cache/` using `pathlib.Path` (existing convention — `.cache/air_quality.parquet`).
+- Keep the `try/except` structure; add cache IO inside the happy path.
+
+**Test scenarios:**
+- Happy path: `get_tempstick_data()` on empty cache → writes cache file, returns dict with real values.
+- Happy path: second call with same `last_checkin` → returns `None`, cache file unchanged.
+- Edge case: cache file exists but contains a different timestamp → returns dict (new reading), overwrites cache.
+- Edge case: cache file deleted mid-run (race condition) → recovers gracefully, writes fresh cache.
+- Edge case: cache file contains corrupt/torn bytes (interrupted SIGTERM during write) → comparison treats it as "different value", collector writes one duplicate row this cycle, cache re-seeds successfully.
+- Error path: API returns 429 (or raises `requests.RequestException`) → returns `None`, cache file not touched (don't corrupt state on transient failure).
+- Error path: API returns 200 but `last_checkin` field missing → still returns dict (don't starve the Sheet of data on API schema drift); cache file NOT touched.
+- Error path: cache write fails (disk full / permission error) → stderr warning logged, dict still returned; test simulates by making `.cache/` read-only.
+
+**Verification:**
+- `uv run pytest -q tests/test_collect_air_quality.py -v` → new test passes alongside existing 22.
+- Manual probe on DGX (via user, since production-collector-run is blocked): after 24h, attic row count in the Sheet for the day is 20-30 (not 288).
+- **PR 2 lands here** (collapsed from old orchestration-only Unit 7):
+  - Full ruff + pytest pass.
+  - Commit as `feat(collector): dedup Temp Stick writes by last_checkin (#26)`.
+  - Open PR 2 referencing #26. Body includes the "observe 24h on DGX" verification note.
+  - PR 2 open, `MERGEABLE`, CI green.
+
+### Phase 2 — PR 3: Apps Script monitor upgrade (#25 + #27)
+
+- [ ] **Unit 8: Expand `CONFIG` with `EXPECTED_SENSORS`, `INDOOR_BASELINE`, and `MONITOR_VERSION`**
+
+**Goal:** Add the new config surfaces; keep existing config unchanged.
+
+**Requirements:** R6, R7, R8
+
+**Dependencies:** Phase 1b merged (soft — test signals reflect honest cadence). Unit 8 itself is code-only and can be drafted pre-merge.
+
+**Files:**
+- Modify: `HVACMonitor_v3.gs` — `CONFIG` dict at lines 36-100, plus a top-of-file `MONITOR_VERSION` constant.
+
+**Approach:**
+- Add a top-of-file constant: `const MONITOR_VERSION = "v3.2026-04-17";` — bumped on every repo edit. `runAllChecks` logs it once per run so the Apps Script execution log grep-ably reveals which repo version is actually deployed (no deploy-drift mystery).
+- Add new top-level CONFIG key `EXPECTED_SENSORS`: dict keyed by sensor_type (`airthings`, `airgradient`, `tempstick`) with `{ maxGapHours: N }` entries. Values per Key Technical Decisions table.
+- Add new top-level CONFIG key `INDOOR_BASELINE`: `{ absoluteThreshold: 3, sustainedMinutes: 30, cooldownMinutes: 60, room: "master_bedroom" }`. Explicit room scoping — this check reads only the canonical indoor sensor, not all rooms.
+- Leave `DATA_GAP_HOURS: 2` in place as a legacy key; mark with a comment that it's deprecated in favor of per-sensor `EXPECTED_SENSORS[type].maxGapHours`.
+
+**Patterns to follow:**
+- Indentation + comment style of the existing CONFIG keys (`OUTDOOR_AQI`, `PRESSURE`, `EFFICIENCY`).
+
+**Test scenarios:**
+- Test expectation: none — config-only change. Validated by downstream units.
+
+**Verification:**
+- Apps Script syntax check via the editor's linter (manual user step) passes.
+
+- [ ] **Unit 9: Rewrite `checkDataCollection` to use time-window scan + per-sensor thresholds**
+
+**Goal:** Fix #25 — detect multi-day outages regardless of write rate.
+
+**Requirements:** R6, R7
+
+**Dependencies:** Unit 8
+
+**Files:**
+- Modify: `HVACMonitor_v3.gs` — `checkDataCollection()` at lines 664-728.
+
+**Approach:**
+- Compute `maxGap = max(CONFIG.EXPECTED_SENSORS[*].maxGapHours)`. Scan rows where `Timestamp >= now - 2 * maxGap` (hours).
+- Build `lastSeen` map as today.
+- Replace `Object.entries(lastSeen)` iteration with iteration over `CONFIG.EXPECTED_SENSORS` entries:
+  - If sensor not in `lastSeen` → treat as stopped (`hoursSince = Infinity` or the full scan window).
+  - Else if `hoursSince > spec.maxGapHours` → stopped.
+  - Else: check for resumption (existing logic: if script property `DATA_GAP_<type>` is set, clear it and emit INFO).
+- Preserve `props.setProperty(gapKey, ...)` and `props.deleteProperty(gapKey)` semantics — the "alert once per gap" behavior is a feature, not a bug.
+- Alert message wording: include the specific `hoursSince` and `maxGapHours` for the stopped sensor.
+
+**Patterns to follow:**
+- Line 690-708 iteration pattern; keep the same conditional structure, swap data source from `lastSeen` keys to `CONFIG.EXPECTED_SENSORS` keys.
+
+**Test scenarios:**
+- Happy path: all sensors writing within their cadence → no alerts.
+- Edge case: Temp Stick silent 2h 45min → no alert (below 3h `maxGapHours`).
+- Edge case: Temp Stick silent 3h 15min → CRITICAL alert "SENSOR(S) STOPPED: attic (tempstick): 3.3h ago".
+- Edge case: all sensors silent 6h (collector down) → CRITICAL for all three, one merged alert.
+- Integration: simulated resumption after a gap → emits INFO "SENSOR(S) RESUMED" once and clears script property.
+
+**Verification:**
+- `test()` function (Unit 11) exercises the new branches. Manual historical replay: feed Apr 13-17 tempstick data through the function; confirm alert would have fired on Apr 13 22:00 (3h after the last valid row at 21:02, plus one hourly trigger tick).
+
+- [ ] **Unit 10: Add new `checkIndoorBaseline` function**
+
+**Goal:** Fix #27 — alert when indoor PM is elevated on absolute scale, independent of outdoor or spike delta.
+
+**Requirements:** R8, R9
+
+**Dependencies:** Unit 8 (uses `CONFIG.INDOOR_BASELINE`)
+
+**Files:**
+- Modify: `HVACMonitor_v3.gs` — add function after `checkIndoorSpike` at line 538.
+
+**Approach:**
+- **CRITICAL — do NOT copy-paste-mirror `checkIndoorSpike`'s row-reading logic.** That function reads the last 6 rows regardless of sensor and silently pins `indoor` to 0 when the latest row happens to be a Temp Stick attic row (empty `Indoor_PM25`). Replicating that pattern would make this check accidentally blind, exactly like today's `checkIndoorSpike`.
+- Instead: pull enough recent rows (scan a window of 60 min with safe margin — e.g., last 30 sheet rows) and **filter to `row[COLS.ROOM] === CONFIG.INDOOR_BASELINE.room`** ('master_bedroom') BEFORE any math.
+- After filtering, take the most recent 6 master_bedroom rows. If fewer than 4 rows remain (sensor gap), skip the check entirely and log that this tick had insufficient data — do not alert on 1-2 data points.
+- Compute `median(Indoor_PM25)` over those filtered rows only.
+- If `median > CONFIG.INDOOR_BASELINE.absoluteThreshold` and not in cooldown (`INDOOR_BASELINE_ALERTED` script property within `cooldownMinutes` of now):
+  - Emit WARNING alert with body:
+    - Indoor PM2.5 (current reading + 30-min median from master bedroom)
+    - Outdoor PM2.5 (current reading from outdoor sensor)
+    - Delta interpretation: `indoor > outdoor` → "filtration failure suspected (indoor exceeds outdoor)"; `indoor < outdoor` → "outdoor infiltration exceeding filter capacity"
+    - Suggested action: "Turn on main HVAC fan to circulate air through MERV 13 return filter"
+  - Set `INDOOR_BASELINE_ALERTED` script property (timestamp).
+- Cooldown is **time-based only** (matches `CONFIG.INDOOR_BASELINE.cooldownMinutes = 60`). No condition-based clearing. This is the same semantic as `checkIndoorSpike`'s cooldown — don't introduce a second pattern.
+
+**Patterns to follow:**
+- `checkIndoorSpike` at 476-538 is the template ONLY for the cooldown + alert-object + `props.setProperty` lifecycle. Do NOT copy its row-reading logic; build fresh filtering on `COLS.ROOM`.
+
+**Test scenarios:**
+- Happy path: indoor 0 µg/m³ (normal) → no alert.
+- Happy path: indoor 2.5 µg/m³ (below threshold) → no alert.
+- Edge case: indoor 3.1 µg/m³ for 30+ min → WARNING alert fires with directional context.
+- Edge case: indoor 5, outdoor 4.5 (Apr 16 19:00 scenario) → fires with "indoor > outdoor: filtration failure suspected" subtext.
+- Edge case: indoor 5, outdoor 100 (hypothetical wildfire) → fires with "infiltration exceeding filter capacity" subtext; `checkAQI` also fires; both are independently useful.
+- Edge case: cooldown suppresses re-alert within 60 min; allows re-alert after cooldown expires.
+- **Critical: filter correctness** — scan window contains 3 master_bedroom + 2 second_bedroom + 1 attic row → only the 3 master_bedroom rows participate in the median; attic/second_bedroom excluded. The test asserts `attic row's Indoor_PM25 = "" (or NaN)` does not appear in the computed median.
+- Edge case: fewer than 4 master_bedroom rows in the window (sensor gap) → check skips silently, no alert (don't fire on 1 data point).
+- Integration: historical replay of Apr 16 18:00-23:59 → alert fires between 18:15-18:45 (R8). No alert on Apr 15 under same outdoor conditions (R9).
+
+**Verification:**
+- `test()` assertions added in Unit 11 confirm Apr 16 and Apr 15 replay outcomes, and confirm the sensor-filter test case.
+
+- [ ] **Unit 11: Wire new check into `runAllChecks` + extend `test()`**
+
+**Goal:** Make the new check fire in production; expose it via the testing harness.
+
+**Requirements:** R8, R9
+
+**Dependencies:** Units 9, 10
+
+**Files:**
+- Modify: `HVACMonitor_v3.gs` — `runAllChecks()` at lines 127-183, and the `test()` function at ~line 1509.
+
+**Approach:**
+- In `runAllChecks()`, call `checkIndoorBaseline()` after `checkIndoorSpike`. Push its alerts to `alerts.you`.
+- Add `console.log(\`Monitor version: ${MONITOR_VERSION}\`);` as the first line of `runAllChecks()` so the Apps Script execution log records which code version actually fired each tick.
+- In `test()`, add assertion groups using **Sheet-reading pattern, not synthetic injection** (Apps Script functions read `SpreadsheetApp.getActiveSpreadsheet()` directly — synthetic injection isn't practical without a test spreadsheet):
+  - `testDataGap`: use the existing Sheet's data; run `checkDataCollection()` and inspect the return value. Assert that if an `EXPECTED_SENSORS` entry has `lastSeen > maxGapHours` ago, it appears in `stoppedSensors`. Temp Stick's historical Apr 13-17 outage (now in git history) can be used as the anchor case.
+  - `testIndoorBaseline`: run `checkIndoorBaseline()` against the current live Sheet. Print the computed median + alert decision. For Apr 16 replay, a manual verification step: set the Sheet's read-range temporarily to a date range where indoor was elevated, rerun, confirm alert fires.
+- Keep the existing `test()` structure (console.log per branch, no assertion library); this matches the Apps Script idiom.
+
+**Patterns to follow:**
+- `testIndoorSpike()` already reads from the live Sheet via `SpreadsheetApp.getActiveSpreadsheet()`. Same mechanism.
+
+**Test scenarios:**
+- Test expectation: the `test()` output in the Apps Script editor must show `testDataGap` and `testIndoorBaseline` branches running to completion, printing computed values + alert decisions.
+
+**Verification + PR 3** (collapsed from old orchestration-only Unit 12):
+- User runs `test()` in Apps Script editor after deploy; console output shows new branches without errors and the `Monitor version: vX.YYYY-MM-DD` line prints.
+- Commit as `feat(monitor): cadence-aware data-gap check + indoor baseline alert (#25, #27)`.
+- Open PR 3 referencing #25 and #27. Body includes:
+  - Summary of the config + check + wiring + `MONITOR_VERSION` changes.
+  - Explicit deploy checklist for the user: "After merge: open Apps Script editor, paste entire file, save, set new Script Properties if needed, run `test()` function, confirm version line matches the PR's `MONITOR_VERSION` bump, optionally trigger a canary data-gap by pausing the collector briefly."
+  - Historical replay results from Unit 10's Apr 16/Apr 15 test scenarios.
+- No auto-merge. User reviews, merges, deploys.
+
+## System-Wide Impact
+
+- **Interaction graph:**
+  - `scripts/_sheets_loader.py` (new) → imported by `refresh_cache.py`, `dashboard.py`, `bench_heatmap.py`. No other callers should emerge from this sprint.
+  - `.cache/tempstick_last_checkin` — new file; read + written only by `collect_with_sheets_api_v2.py`. No other readers.
+  - `HVACMonitor_v3.gs::runAllChecks` — existing orchestrator; gains one call to `checkIndoorBaseline`.
+  - Script Properties: new key `INDOOR_BASELINE_ALERTED`. Existing `DATA_GAP_<type>` keys remain compatible (same lifecycle semantics).
+- **Error propagation:**
+  - Shared loader: raises `RuntimeError` on missing creds / empty sheet (matches current behavior). Callers handle; no new swallowing.
+  - Collector dedup: cache-IO failures log to stderr but don't block returning the dict (worse to drop a reading than write a duplicate). A "dedup unhealthy" counter tracks consecutive read failures so a broken dedup doesn't stay silent for weeks.
+  - Monitor: Apps Script exceptions in new checks propagate to the existing try/catch in `runAllChecks` (if present) or log-and-continue.
+- **State lifecycle risks:**
+  - `.cache/tempstick_last_checkin` missing → self-heals (next call writes it). ✓
+  - `.cache/tempstick_last_checkin` corrupted (partial write) → mitigated by atomic write (`.tmp` + `os.replace`). Worst case if replace itself tears: one duplicate row, next run reseeds. ✓
+  - `.cache/tempstick_dedup_health` counter → observable via collector log tail; stale cache surfaces as a daily-ish warning, not a silent failure. ✓
+  - Apps Script Script Properties leak across script runs — `INDOOR_BASELINE_ALERTED` cooldown is self-clearing on median-below-threshold. ✓
+- **API surface parity:**
+  - No external-facing API changes. `dashboard.py`'s streamlit cache key unchanged (`load_raw`). Public function signatures in new loader match existing callers' expectations.
+- **Integration coverage:**
+  - Cross-layer: `checkDataCollection` now depends on Sheet data honestly reflecting sensor cadence. After #26 dedup ships, Temp Stick writes are sparse; the new time-window scan must handle this correctly. Unit 9's integration test exercises this.
+- **Unchanged invariants:** Sheet schema (18 col), DGX collector path pin, hourly trigger, alert-email routing, all existing check functions. See Scope Boundaries for the full list — not duplicated here.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|---|---|
+| Shared loader refactor introduces subtle behavior drift | Unit 1 test scenarios cover the schema-gate boundary explicitly. Unit 4 pre-fix diagnostic checks whether non-tempstick sensors are affected. Revert note: `rm .cache/air_quality.parquet` after `git revert` so streamlit's cached DataFrame also invalidates. |
+| Dedup cache-file IO on DGX fails silently | Atomic writes via `.tmp` + `os.replace`. Stderr warning on read failure. `.cache/tempstick_dedup_health` counter makes prolonged breakage observable (daily-ish grep-able log line). User observes 24h row counts post-deploy to confirm. |
+| `INDOOR_BASELINE.absoluteThreshold = 3` produces false alerts during cooking / candles / vacation / wildfire | `checkIndoorSpike` catches true spikes (+5 delta) first. Cooldown 60min. **Pre-Phase-2 backtest unit (optional, see Open Questions)** measures the 9-month base rate of "30-min rolling median > 3" to validate the threshold before ship. If base rate >1-2/week, tune before merging. |
+| Re-alert thrashing if indoor PM oscillates around threshold | 60-min cooldown. If thrash observed post-deploy, add hysteresis (exit below a lower threshold). Defer unless observed. |
+| User runs `test()` with stale `Script Properties` from prior experiments | Deploy checklist: "Optional — clear all `DATA_GAP_*` and `INDOOR_BASELINE_ALERTED` properties before first test run." |
+| #28 retroactive data recovery surprises the dashboard — new non-NaN values in historical charts | Positive surprise, matches R1. Dashboard handles gracefully. |
+| Wife's surgery window compresses Phase 2 deploy timing | Phase 1 (PRs 1 + 2) delivers data-integrity + dedup wins independently. Phase 2 PR can sit open for days with no risk — #27 fix for yesterday's scenario waits, but the sprint closure doesn't block the surgery window. |
+| Apps Script deploy drift — repo version ≠ running version | `MONITOR_VERSION` constant logged per `runAllChecks()` invocation. Future drift is grep-able from execution log, not a mystery. |
+
+Deployment procedure (moved out of the risk register — this is a checklist, not a risk):
+- Paste entire file when deploying Apps Script changes. Partial pastes can throw at runtime; no code-level guard covers that fully.
+
+## Documentation / Operational Notes
+
+- **Changelog**: Three entries for v0.6.0-dev (one per PR). Each entry should reference the fixing issue number.
+- **`docs/LESSONS_LEARNED.md`**: After Phase 1a merge, add a lessons entry about date-gating data-repair logic (from #28).
+- **`HVACMonitor_v3.gs` top comment block**: Update the "KEY CONCEPTS" section to mention per-sensor cadence and indoor baseline check.
+- **Monitoring**: No new operational dashboards. Existing collector logs + email alerts are sufficient. User reviews 24h post-Phase-1b merge to confirm dedup worked (row count).
+- **Rollback paths**: Each PR is a clean revert if problems emerge. Apps Script: user re-pastes prior `HVACMonitor_v3.gs` version from git history.
+
+## Sources & References
+
+- **Origin issues:**
+  - #25 — https://github.com/minghsuy/hvac-air-quality-analysis/issues/25
+  - #26 — https://github.com/minghsuy/hvac-air-quality-analysis/issues/26
+  - #27 — https://github.com/minghsuy/hvac-air-quality-analysis/issues/27
+  - #28 — https://github.com/minghsuy/hvac-air-quality-analysis/issues/28
+- **Related PRs (merged this week):**
+  - #24 — collector UA fix (precondition — attic API access restored)
+  - #23 — repo tidy-pass + anti-regrowth pre-push guardrail (provides the `scripts/hooks/pre-push` discipline these PRs must pass)
+- **Critical code paths:**
+  - `collect_with_sheets_api_v2.py:310-346` (`get_tempstick_data`)
+  - `collect_with_sheets_api_v2.py:388` (`build_temp_only_row`) — row-shape invariant to preserve
+  - `scripts/refresh_cache.py:62-102` — reference for the shared loader
+  - `scripts/dashboard.py:60-110` — streamlit-wrapped copy
+  - `scripts/bench_heatmap.py:23-95` — third copy
+  - `HVACMonitor_v3.gs:36-100` (`CONFIG`)
+  - `HVACMonitor_v3.gs:127-183` (`runAllChecks`)
+  - `HVACMonitor_v3.gs:476-538` (`checkIndoorSpike` — pattern for `checkIndoorBaseline`)
+  - `HVACMonitor_v3.gs:664-728` (`checkDataCollection` — rewrite target)
+- **Session context:** This plan was built immediately after filing #27 and #28 in the same conversation where #25, #26, #23, and #24 were filed or merged. Fresh knowledge of every code path cited.

--- a/scripts/_sheets_loader.py
+++ b/scripts/_sheets_loader.py
@@ -1,0 +1,117 @@
+"""Shared Google Sheets → pandas DataFrame loader.
+
+Previously duplicated across refresh_cache.py, dashboard.py, and bench_heatmap.py
+(three near-identical copies). Extracted here so the column-shift repair logic
+lives in one place with a correct timestamp gate.
+
+The 18-column schema stabilized on 2025-09-01. Pre-stabilization rows
+(Jul-Aug 2025) had 17 columns and the legacy shift-repair still applies.
+Post-stabilization rows under 18 columns are Google Sheets API truncation
+of trailing empty strings (most visible on Temp Stick attic rows, which
+have 6 trailing empties and land as 12 cols). Those rows must NOT be
+shifted — their values are correctly positioned, just padded.
+
+Callers invoke as: `from _sheets_loader import load_sheet_as_df`.
+When a script is run via `python scripts/foo.py` or `streamlit run scripts/foo.py`,
+`scripts/` is `sys.path[0]`, so _sheets_loader is importable as a sibling
+module (no `scripts.` prefix, no package `__init__.py` needed).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+from google.oauth2 import service_account
+from googleapiclient.discovery import build
+
+EXPECTED_COLS = 18
+SHEET_RANGE = "A:R"
+SCHEMA_STABILIZED = pd.Timestamp("2025-09-01")
+
+NUMERIC_COLS = [
+    "Indoor_PM25",
+    "Outdoor_PM25",
+    "Filter_Efficiency",
+    "Indoor_CO2",
+    "Outdoor_CO2",
+    "Indoor_VOC",
+    "Indoor_NOX",
+    "Indoor_Temp",
+    "Indoor_Humidity",
+    "Indoor_Radon",
+    "Outdoor_Temp",
+    "Outdoor_Humidity",
+    "Outdoor_VOC",
+    "Outdoor_NOX",
+]
+
+# Columns whose values shifted when the schema grew from 17 to 18 cols.
+# Only applied to pre-SCHEMA_STABILIZED rows.
+SHIFTED_COLS = [
+    "Indoor_Temp",
+    "Indoor_Humidity",
+    "Indoor_Radon",
+    "Outdoor_CO2",
+    "Outdoor_Temp",
+    "Outdoor_Humidity",
+    "Outdoor_VOC",
+    "Outdoor_NOX",
+]
+
+
+def _fetch_values(spreadsheet_id: str, sheet_tab: str, creds_path: str) -> list[list[str]]:
+    """Google Sheets API call. Returns raw 2-D list (headers + data rows)."""
+    credentials = service_account.Credentials.from_service_account_file(
+        creds_path,
+        scopes=["https://www.googleapis.com/auth/spreadsheets.readonly"],
+    )
+    service = build("sheets", "v4", credentials=credentials, cache_discovery=False)
+    range_name = f"{sheet_tab}!{SHEET_RANGE}" if sheet_tab else SHEET_RANGE
+    result = (
+        service.spreadsheets()
+        .values()
+        .get(spreadsheetId=spreadsheet_id, range=range_name)
+        .execute()
+    )
+    values = result.get("values", [])
+    if not values:
+        raise RuntimeError("Sheet returned no rows")
+    return values
+
+
+def _values_to_df(values: list[list[str]]) -> pd.DataFrame:
+    """Pure transform: 2-D list → DataFrame with correct shift-repair gating.
+
+    Factored out so tests can mock this without mocking the whole API chain.
+    """
+    headers = values[0]
+    n_cols = len(headers)
+    data_rows = values[1:]
+
+    orig_cols = np.fromiter((len(r) for r in data_rows), dtype=np.int16, count=len(data_rows))
+    padded = [
+        row + [""] * (n_cols - len(row)) if len(row) < n_cols else row[:n_cols] for row in data_rows
+    ]
+
+    df = pd.DataFrame(padded, columns=headers)
+    df["Timestamp"] = pd.to_datetime(df["Timestamp"], errors="coerce")
+
+    for col in set(NUMERIC_COLS) & set(df.columns):
+        df[col] = pd.to_numeric(df[col], errors="coerce")
+
+    # Shift-repair: only for pre-stabilization rows. Modern rows under
+    # EXPECTED_COLS are Sheets API trailing-empty truncation, not schema shift.
+    shifted = (orig_cols < EXPECTED_COLS) & (df["Timestamp"] < SCHEMA_STABILIZED)
+    for col in set(SHIFTED_COLS) & set(df.columns):
+        df.loc[shifted, col] = np.nan
+
+    return df.dropna(subset=["Timestamp"]).sort_values("Timestamp").reset_index(drop=True)
+
+
+def load_sheet_as_df(spreadsheet_id: str, sheet_tab: str, creds_path: str) -> pd.DataFrame:
+    """Load a Google Sheet tab into a DataFrame.
+
+    Raises RuntimeError if the sheet is empty. Callers own .env loading.
+    """
+    values = _fetch_values(spreadsheet_id, sheet_tab, creds_path)
+    return _values_to_df(values)

--- a/scripts/bench_heatmap.py
+++ b/scripts/bench_heatmap.py
@@ -7,11 +7,10 @@ Shows where the real bottleneck is and what GPU acceleration actually helps.
 import os
 import time
 
-import numpy as np
 import pandas as pd
 from dotenv import load_dotenv
-from google.oauth2 import service_account
-from googleapiclient.discovery import build
+
+from _sheets_loader import load_sheet_as_df
 
 load_dotenv(os.path.join(os.path.dirname(os.path.dirname(__file__)), ".env"))
 
@@ -24,62 +23,7 @@ def fetch_from_sheets():
     spreadsheet_id = os.environ["GOOGLE_SPREADSHEET_ID"]
     sheet_tab = os.environ.get("GOOGLE_SHEET_TAB", "")
     creds_path = os.path.join(os.path.dirname(os.path.dirname(__file__)), "google-credentials.json")
-    credentials = service_account.Credentials.from_service_account_file(
-        creds_path, scopes=["https://www.googleapis.com/auth/spreadsheets.readonly"]
-    )
-    service = build("sheets", "v4", credentials=credentials)
-    sheet = service.spreadsheets()
-    range_name = f"{sheet_tab}!A:R" if sheet_tab else "A:R"
-    result = sheet.values().get(spreadsheetId=spreadsheet_id, range=range_name).execute()
-    values = result.get("values", [])
-
-    headers = values[0]
-    n_cols = len(headers)
-    padded = []
-    orig_cols = []
-    for row in values[1:]:
-        orig_cols.append(len(row))
-        r = row + [""] * (n_cols - len(row)) if len(row) < n_cols else row[:n_cols]
-        padded.append(r)
-
-    df = pd.DataFrame(padded, columns=headers)
-    df["_orig_cols"] = orig_cols
-    df["Timestamp"] = pd.to_datetime(df["Timestamp"], errors="coerce")
-    for col in [
-        "Indoor_PM25",
-        "Outdoor_PM25",
-        "Filter_Efficiency",
-        "Indoor_CO2",
-        "Outdoor_CO2",
-        "Indoor_VOC",
-        "Indoor_NOX",
-        "Indoor_Temp",
-        "Indoor_Humidity",
-        "Indoor_Radon",
-        "Outdoor_Temp",
-        "Outdoor_Humidity",
-        "Outdoor_VOC",
-        "Outdoor_NOX",
-    ]:
-        if col in df.columns:
-            df[col] = pd.to_numeric(df[col], errors="coerce")
-
-    shifted = df["_orig_cols"] < 18
-    for col in [
-        "Indoor_Temp",
-        "Indoor_Humidity",
-        "Indoor_Radon",
-        "Outdoor_CO2",
-        "Outdoor_Temp",
-        "Outdoor_Humidity",
-        "Outdoor_VOC",
-        "Outdoor_NOX",
-    ]:
-        if col in df.columns:
-            df.loc[shifted, col] = np.nan
-
-    df = df.dropna(subset=["Timestamp"]).sort_values("Timestamp").reset_index(drop=True)
-    return df
+    return load_sheet_as_df(spreadsheet_id, sheet_tab, creds_path)
 
 
 def build_heatmap_pandas(df):

--- a/scripts/dashboard.py
+++ b/scripts/dashboard.py
@@ -13,8 +13,8 @@ import numpy as np
 import pandas as pd
 import streamlit as st
 from dotenv import load_dotenv
-from google.oauth2 import service_account
-from googleapiclient.discovery import build
+
+from _sheets_loader import load_sheet_as_df
 
 load_dotenv()
 
@@ -49,71 +49,17 @@ COLORS = {
 
 
 def _fetch_from_sheets():
-    """Fetch raw data from Google Sheets API (~3.5s)."""
+    """Fetch raw data from Google Sheets API (~3.5s) via the shared loader."""
     spreadsheet_id = os.getenv("GOOGLE_SPREADSHEET_ID")
     sheet_tab = os.getenv("GOOGLE_SHEET_TAB", "")
     creds_path = os.path.join(os.path.dirname(os.path.dirname(__file__)), "google-credentials.json")
-    credentials = service_account.Credentials.from_service_account_file(
-        creds_path, scopes=["https://www.googleapis.com/auth/spreadsheets.readonly"]
-    )
-    service = build("sheets", "v4", credentials=credentials)
-    sheet = service.spreadsheets()
-    range_name = f"{sheet_tab}!A:R" if sheet_tab else "A:R"
-    result = sheet.values().get(spreadsheetId=spreadsheet_id, range=range_name).execute()
-    values = result.get("values", [])
-
-    headers = values[0]
-    n_cols = len(headers)
-    padded, orig_cols = [], []
-    for row in values[1:]:
-        orig_cols.append(len(row))
-        r = row + [""] * (n_cols - len(row)) if len(row) < n_cols else row[:n_cols]
-        padded.append(r)
-
-    df = pd.DataFrame(padded, columns=headers)
-    df["_orig_cols"] = orig_cols
-    df["Timestamp"] = pd.to_datetime(df["Timestamp"], errors="coerce")
-    for col in [
-        "Indoor_PM25",
-        "Outdoor_PM25",
-        "Filter_Efficiency",
-        "Indoor_CO2",
-        "Outdoor_CO2",
-        "Indoor_VOC",
-        "Indoor_NOX",
-        "Indoor_Temp",
-        "Indoor_Humidity",
-        "Indoor_Radon",
-        "Outdoor_Temp",
-        "Outdoor_Humidity",
-        "Outdoor_VOC",
-        "Outdoor_NOX",
-    ]:
-        if col in df.columns:
-            df[col] = pd.to_numeric(df[col], errors="coerce")
-
-    shifted = df["_orig_cols"] < 18
-    for col in [
-        "Indoor_Temp",
-        "Indoor_Humidity",
-        "Indoor_Radon",
-        "Outdoor_CO2",
-        "Outdoor_Temp",
-        "Outdoor_Humidity",
-        "Outdoor_VOC",
-        "Outdoor_NOX",
-    ]:
-        if col in df.columns:
-            df.loc[shifted, col] = np.nan
-
-    df = df.dropna(subset=["Timestamp"]).sort_values("Timestamp").reset_index(drop=True)
-    return df
+    return load_sheet_as_df(spreadsheet_id, sheet_tab, creds_path)
 
 
 def _save_parquet(df):
     """Save cleaned DataFrame to local Parquet cache."""
     os.makedirs(os.path.dirname(PARQUET_CACHE), exist_ok=True)
-    df.drop(columns=["_orig_cols"], errors="ignore").to_parquet(PARQUET_CACHE)
+    df.to_parquet(PARQUET_CACHE)
 
 
 def load_raw(force_refresh=False):

--- a/scripts/refresh_cache.py
+++ b/scripts/refresh_cache.py
@@ -1,9 +1,5 @@
 #!/usr/bin/env python3
 # Headless refresh of .cache/air_quality.parquet from Google Sheets.
-# Mirrors scripts/dashboard.py::_fetch_from_sheets + _save_parquet — inlined
-# rather than imported because dashboard.py imports streamlit at module scope.
-# TODO: extract scripts/_sheets_loader.py to dedupe this, dashboard.py, and
-#   bench_heatmap.py (three near-identical copies of the same fetch pipeline).
 # Invoke manually when you want fresh data:  uv run python scripts/refresh_cache.py
 
 import os
@@ -14,92 +10,22 @@ from datetime import datetime
 
 socket.setdefaulttimeout(45)
 
-import numpy as np  # noqa: E402
-import pandas as pd  # noqa: E402
 from dotenv import load_dotenv  # noqa: E402
-from google.oauth2 import service_account  # noqa: E402
-from googleapiclient.discovery import build  # noqa: E402
+
+from _sheets_loader import load_sheet_as_df  # noqa: E402
 
 REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 PARQUET_CACHE = os.path.join(REPO_ROOT, ".cache", "air_quality.parquet")
 CREDS_PATH = os.path.join(REPO_ROOT, "google-credentials.json")
 
-# Sheet schema: 18 columns (A:R). Pre-Sep 2025 rows had 17 and need the
-# column-shift repair applied via SHIFTED_COLS below.
-EXPECTED_COLS = 18
-SHEET_RANGE = "A:R"
 
-NUMERIC_COLS = [
-    "Indoor_PM25",
-    "Outdoor_PM25",
-    "Filter_Efficiency",
-    "Indoor_CO2",
-    "Outdoor_CO2",
-    "Indoor_VOC",
-    "Indoor_NOX",
-    "Indoor_Temp",
-    "Indoor_Humidity",
-    "Indoor_Radon",
-    "Outdoor_Temp",
-    "Outdoor_Humidity",
-    "Outdoor_VOC",
-    "Outdoor_NOX",
-]
-# Columns whose positions shifted when the schema went from 17 to 18 cols.
-# For rows with len(row) < EXPECTED_COLS, these values are unreliable.
-SHIFTED_COLS = [
-    "Indoor_Temp",
-    "Indoor_Humidity",
-    "Indoor_Radon",
-    "Outdoor_CO2",
-    "Outdoor_Temp",
-    "Outdoor_Humidity",
-    "Outdoor_VOC",
-    "Outdoor_NOX",
-]
-
-
-def fetch_from_sheets() -> pd.DataFrame:
+def fetch_from_sheets():
     load_dotenv(os.path.join(REPO_ROOT, ".env"))
     spreadsheet_id = os.getenv("GOOGLE_SPREADSHEET_ID")
     sheet_tab = os.getenv("GOOGLE_SHEET_TAB", "")
     if not spreadsheet_id:
         raise RuntimeError("GOOGLE_SPREADSHEET_ID missing from .env")
-
-    credentials = service_account.Credentials.from_service_account_file(
-        CREDS_PATH, scopes=["https://www.googleapis.com/auth/spreadsheets.readonly"]
-    )
-    service = build("sheets", "v4", credentials=credentials, cache_discovery=False)
-    range_name = f"{sheet_tab}!{SHEET_RANGE}" if sheet_tab else SHEET_RANGE
-    result = (
-        service.spreadsheets()
-        .values()
-        .get(spreadsheetId=spreadsheet_id, range=range_name)
-        .execute()
-    )
-    values = result.get("values", [])
-    if not values:
-        raise RuntimeError("Sheet returned no rows")
-
-    headers = values[0]
-    n_cols = len(headers)
-    data_rows = values[1:]
-    orig_cols = np.fromiter((len(r) for r in data_rows), dtype=np.int16, count=len(data_rows))
-    padded = [
-        row + [""] * (n_cols - len(row)) if len(row) < n_cols else row[:n_cols] for row in data_rows
-    ]
-
-    df = pd.DataFrame(padded, columns=headers)
-    df["Timestamp"] = pd.to_datetime(df["Timestamp"], errors="coerce")
-
-    for col in set(NUMERIC_COLS) & set(df.columns):
-        df[col] = pd.to_numeric(df[col], errors="coerce")
-
-    shifted = orig_cols < EXPECTED_COLS
-    for col in set(SHIFTED_COLS) & set(df.columns):
-        df.loc[shifted, col] = np.nan
-
-    return df.dropna(subset=["Timestamp"]).sort_values("Timestamp").reset_index(drop=True)
+    return load_sheet_as_df(spreadsheet_id, sheet_tab, CREDS_PATH)
 
 
 def main() -> int:

--- a/tests/test_collect_air_quality.py
+++ b/tests/test_collect_air_quality.py
@@ -342,3 +342,154 @@ class TestEfficiencyEdgeCases:
         """Test when both indoor and outdoor are zero"""
         # Edge case: 0/0 should return 100% (perfect efficiency when no pollution)
         assert collector.calculate_efficiency(0, 0) == 100.0
+
+
+# ---------------------------------------------------------------------------
+# Shared Sheets loader (scripts/_sheets_loader.py) — extracted from three
+# near-identical copies in refresh_cache.py, dashboard.py, and bench_heatmap.py
+# ---------------------------------------------------------------------------
+
+sys.path.insert(0, "scripts")  # make _sheets_loader importable as a sibling
+
+import _sheets_loader  # noqa: E402
+
+
+HEADERS = [
+    "Timestamp",
+    "Sensor_ID",
+    "Room",
+    "Sensor_Type",
+    "Indoor_PM25",
+    "Outdoor_PM25",
+    "Filter_Efficiency",
+    "Indoor_CO2",
+    "Indoor_VOC",
+    "Indoor_NOX",
+    "Indoor_Temp",
+    "Indoor_Humidity",
+    "Indoor_Radon",
+    "Outdoor_CO2",
+    "Outdoor_Temp",
+    "Outdoor_Humidity",
+    "Outdoor_VOC",
+    "Outdoor_NOX",
+]
+
+
+class TestSheetsLoader:
+    """Test the shared Google Sheets → DataFrame loader."""
+
+    def test_modern_18col_row_preserves_all_values(self):
+        """Full 18-column post-stabilization row: nothing gets nulled."""
+        values = [
+            HEADERS,
+            [
+                "2026-02-10 12:00:00",
+                "airthings_abc",
+                "master_bedroom",
+                "airthings",
+                "1.5",  # Indoor_PM25
+                "4.0",  # Outdoor_PM25
+                "62.5",  # Filter_Efficiency
+                "600",  # Indoor_CO2
+                "100",  # Indoor_VOC
+                "5",  # Indoor_NOX
+                "22.5",  # Indoor_Temp ← must survive
+                "45.0",  # Indoor_Humidity ← must survive
+                "50",  # Indoor_Radon
+                "420",  # Outdoor_CO2
+                "15.0",  # Outdoor_Temp
+                "60.0",  # Outdoor_Humidity
+                "80",  # Outdoor_VOC
+                "3",  # Outdoor_NOX
+            ],
+        ]
+        df = _sheets_loader._values_to_df(values)
+        assert len(df) == 1
+        assert df.iloc[0]["Indoor_Temp"] == 22.5
+        assert df.iloc[0]["Indoor_Humidity"] == 45.0
+        assert df.iloc[0]["Outdoor_Temp"] == 15.0
+
+    def test_legacy_17col_row_triggers_shift_repair(self):
+        """Pre-2025-09-01 row with 17 columns: shift-repair nulls Indoor_Temp etc."""
+        # Legacy short row — missing last column; shift-repair nulls the SHIFTED_COLS
+        values = [
+            HEADERS,
+            [
+                "2025-08-15 10:00:00",
+                "airthings_abc",
+                "master_bedroom",
+                "airthings",
+                "1.5",
+                "4.0",
+                "62.5",
+                "600",
+                "100",
+                "5",
+                "22.5",  # Indoor_Temp  — nulled by shift-repair
+                "45.0",  # Indoor_Humidity — nulled
+                "50",  # Indoor_Radon — nulled
+                "420",  # Outdoor_CO2 — nulled
+                "15.0",  # Outdoor_Temp — nulled
+                "60.0",  # Outdoor_Humidity — nulled
+                "80",  # Outdoor_VOC — nulled
+                # 17 values only — missing Outdoor_NOX
+            ],
+        ]
+        df = _sheets_loader._values_to_df(values)
+        assert len(df) == 1
+        # All SHIFTED_COLS for this legacy short row must be NaN
+        import math
+
+        assert math.isnan(df.iloc[0]["Indoor_Temp"])
+        assert math.isnan(df.iloc[0]["Indoor_Humidity"])
+        assert math.isnan(df.iloc[0]["Outdoor_Temp"])
+        # But non-shifted columns stay intact
+        assert df.iloc[0]["Indoor_PM25"] == 1.5
+        assert df.iloc[0]["Filter_Efficiency"] == 62.5
+
+    def test_modern_12col_tempstick_row_preserves_temp_humidity(self):
+        """Post-stabilization Temp Stick row: Sheets trims 6 trailing empties,
+        row lands as 12 cols, but shift-repair MUST NOT fire."""
+        values = [
+            HEADERS,
+            [
+                "2026-02-10 12:00:00",
+                "tempstick_abcd",
+                "attic",
+                "tempstick",
+                "",  # Indoor_PM25 (empty — tempstick doesn't report PM)
+                "",  # Outdoor_PM25
+                "",  # Filter_Efficiency
+                "",  # Indoor_CO2
+                "",  # Indoor_VOC
+                "",  # Indoor_NOX
+                "20.06",  # Indoor_Temp ← MUST SURVIVE
+                "35.5",  # Indoor_Humidity ← MUST SURVIVE
+                # 12 values total — Sheets API trimmed the 6 trailing empties
+            ],
+        ]
+        df = _sheets_loader._values_to_df(values)
+        assert len(df) == 1
+        assert df.iloc[0]["Indoor_Temp"] == 20.06
+        assert df.iloc[0]["Indoor_Humidity"] == 35.5
+
+    def test_header_only_sheet_returns_empty_df(self):
+        """Sheet with only the header row returns an empty DataFrame."""
+        values = [HEADERS]
+        df = _sheets_loader._values_to_df(values)
+        assert len(df) == 0
+        assert list(df.columns) == HEADERS
+
+    def test_fetch_values_raises_on_empty_sheet(self):
+        """Empty Sheet API response raises RuntimeError with a clear message."""
+        import pytest
+
+        mock_service = MagicMock()
+        mock_service.spreadsheets.return_value.values.return_value.get.return_value.execute.return_value = {}
+        with (
+            patch("_sheets_loader.build", return_value=mock_service),
+            patch("_sheets_loader.service_account.Credentials.from_service_account_file"),
+        ):
+            with pytest.raises(RuntimeError, match="no rows"):
+                _sheets_loader._fetch_values("fake_id", "fake_tab", "fake_creds.json")


### PR DESCRIPTION
## Summary

Closes #28. Completes Phase 1a of the four-issue monitoring sprint (plan: `docs/plans/2026-04-17-001-fix-monitoring-sprint-plan.md`).

Three copies of the Google Sheets → DataFrame pipeline (`scripts/refresh_cache.py`, `scripts/dashboard.py`, `scripts/bench_heatmap.py`) are consolidated into `scripts/_sheets_loader.py`. The critical fix lives in the shared module: the **column-shift repair is now gated by `Timestamp < 2025-09-01`**. Post-stabilization rows with fewer than 18 columns are Google Sheets API trailing-empty truncation (most visibly Temp Stick attic rows, which have 6 empty trailing columns and land as 12), not schema shifts — and must keep their values.

## Retroactive data recovery

Before this PR:
```
attic rows total:                 15,775
attic rows with valid Indoor_Temp:      0
```
After (verified via `uv run python scripts/refresh_cache.py` on this branch):
```
attic rows total:                 15,775
attic rows with valid Indoor_Temp: 15,775    (100%)
Temp range:                       10.1 .. 44.8 °C (plausible attic across seasons)
Earliest recovered row:           2026-02-08 22:01:47  (Temp Stick install date)
```

2+ months of silent data loss reversed by the date-gated repair. ERV over-temp-risk analysis using attic data is now possible for the first time since the Temp Stick was installed.

## Commits (5)

1. `docs: add monitoring sprint plan (#25 #26 #27 #28)` — ce-plan + document-review deepened plan doc
2. `refactor: extract scripts/_sheets_loader.py with date-gated shift repair (#28)` — new module + 5 unit tests
3. `refactor: migrate refresh_cache.py to shared _sheets_loader`
4. `refactor: migrate dashboard.py to shared _sheets_loader`
5. `refactor: migrate bench_heatmap.py to shared _sheets_loader`

## Test plan

- [x] `uv run ruff check .` — clean
- [x] `uv run ruff format --check .` — clean (23 files)
- [x] `uv run pytest -q` — 27 passed (22 existing + 5 new `TestSheetsLoader`)
- [x] `uv run python scripts/refresh_cache.py` — parquet rebuilds, 142,849 rows, historical attic `Indoor_Temp` recovered
- [x] Sanity sweep: no non-tempstick post-Sep-2025 rows surprised by the gate (diagnostic confirms only tempstick was affected by the old bug)
- [ ] **Post-merge**: pull on DGX (`git pull`); streamlit dashboard picks up restored attic charts on next reload; `rm .cache/air_quality.parquet && uv run python scripts/refresh_cache.py` if needed to force cache rebuild

## Next in the sprint

- **Phase 1b (PR 2)**: collector-side dedup of Temp Stick writes by `last_checkin` (closes #26) — separate PR, touches only `collect_with_sheets_api_v2.py` + tests.
- **Phase 2 (PR 3)**: bundled Apps Script upgrade — per-sensor cadence data-gap check + new `checkIndoorBaseline` (closes #25 and #27). Held until Phase 1b lands + 24h dedup verification; then deployed by copy-paste to Apps Script editor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)