### PR TITLE
Phase 1b: dedup Temp Stick writes by last_checkin (#26)

### DIFF
--- a/collect_with_sheets_api_v2.py
+++ b/collect_with_sheets_api_v2.py
@@ -5,8 +5,10 @@ Updated to write to a specific sheet tab (for cleaned data)
 """
 
 import os
+import sys
 import requests
 from datetime import datetime
+from pathlib import Path
 from dotenv import load_dotenv
 from google.oauth2 import service_account
 from googleapiclient.discovery import build
@@ -307,8 +309,49 @@ def get_airgradient_data(serial, room, ip=None):
         return None
 
 
+# Temp Stick updates ~once per hour to preserve battery life. Polling every
+# 5 minutes would write 11 duplicate rows per cycle unless we gate on
+# last_checkin. Cache dir is gitignored (.cache/).
+_TEMPSTICK_CACHE = Path(SCRIPT_DIR) / ".cache" / "tempstick_last_checkin"
+
+
+def _read_tempstick_cache():
+    """Return the cached last_checkin string, or None if missing/unreadable.
+    Corrupt/torn cache files (e.g., SIGTERM mid-write) read as ``None`` →
+    caller treats as 'no prior state' and writes one row (self-healing).
+    Catches broadly (OSError, UnicodeDecodeError, ValueError) because every
+    read failure should degrade to 'no prior state', not starve the Sheet."""
+    try:
+        return _TEMPSTICK_CACHE.read_text().strip() or None
+    except FileNotFoundError:
+        return None
+    except (OSError, UnicodeDecodeError, ValueError) as e:
+        print(f"  ⚠️ Temp Stick cache read failed ({e}); proceeding without dedup", file=sys.stderr)
+        return None
+
+
+def _write_tempstick_cache(checkin):
+    """Atomically update the cache (.tmp + rename) so SIGTERM can't tear a write.
+    Cache write failures are non-fatal — better one duplicate row than a dropped reading."""
+    try:
+        _TEMPSTICK_CACHE.parent.mkdir(parents=True, exist_ok=True)
+        tmp = _TEMPSTICK_CACHE.with_suffix(".tmp")
+        tmp.write_text(checkin)
+        os.replace(tmp, _TEMPSTICK_CACHE)
+    except OSError as e:
+        print(
+            f"  ⚠️ Temp Stick cache write failed ({e}); dedup may lapse this cycle", file=sys.stderr
+        )
+
+
 def get_tempstick_data():
-    """Get temperature/humidity data from Temp Stick WiFi sensor in attic"""
+    """Get temperature/humidity data from Temp Stick WiFi sensor in attic.
+
+    Returns ``None`` when:
+      - API key/sensor ID missing
+      - API non-200 / request exception
+      - Response's ``last_checkin`` matches the cached value (no new reading to record)
+    """
     if not TEMP_STICK_API_KEY or not TEMP_STICK_SENSOR_ID:
         return None
 
@@ -331,6 +374,16 @@ def get_tempstick_data():
             return None
 
         data = response.json().get("data", {})
+
+        # Dedup: if the sensor hasn't checked in again since our last row,
+        # skip this cycle entirely. Missing last_checkin (API schema drift)
+        # falls through to the write path so we don't starve the Sheet.
+        checkin = data.get("last_checkin")
+        if checkin:
+            cached = _read_tempstick_cache()
+            if cached == checkin:
+                return None
+            _write_tempstick_cache(checkin)
 
         # Temp Stick API returns °C (dashboard displays °F but API is metric)
         temp_c = data.get("last_temp")

--- a/tests/test_collect_air_quality.py
+++ b/tests/test_collect_air_quality.py
@@ -322,6 +322,145 @@ class TestTempStickAPI:
         assert data is None
 
 
+class TestTempStickDedup:
+    """Dedup by last_checkin — skip Sheet write when the sensor hasn't reported
+    a fresh reading. Temp Stick updates ~hourly for battery life, so polling
+    every 5 min would otherwise write 11 duplicates per cycle."""
+
+    def _response(self, checkin, temp=20.06, humidity=35.5):
+        r = MagicMock()
+        r.status_code = 200
+        r.json.return_value = {
+            "data": {
+                "last_checkin": checkin,
+                "last_temp": temp,
+                "last_humidity": humidity,
+            }
+        }
+        return r
+
+    @patch("requests.get")
+    def test_writes_cache_on_first_call(self, mock_get, tmp_path):
+        """Empty cache → dict returned + cache populated with the checkin value."""
+        cache = tmp_path / "tempstick_last_checkin"
+        mock_get.return_value = self._response("2026-04-17 15:02:02")
+
+        with (
+            patch.object(collector, "TEMP_STICK_API_KEY", "k"),
+            patch.object(collector, "TEMP_STICK_SENSOR_ID", "TS00XXTST1"),
+            patch.object(collector, "_TEMPSTICK_CACHE", cache),
+        ):
+            data = collector.get_tempstick_data()
+
+        assert data is not None
+        assert data["temp"] == 20.06
+        assert cache.read_text() == "2026-04-17 15:02:02"
+
+    @patch("requests.get")
+    def test_skips_when_checkin_unchanged(self, mock_get, tmp_path):
+        """Cache matches API's last_checkin → returns None, Sheet write skipped."""
+        cache = tmp_path / "tempstick_last_checkin"
+        cache.write_text("2026-04-17 15:02:02")
+        mock_get.return_value = self._response("2026-04-17 15:02:02")
+
+        with (
+            patch.object(collector, "TEMP_STICK_API_KEY", "k"),
+            patch.object(collector, "TEMP_STICK_SENSOR_ID", "TS00XXTST1"),
+            patch.object(collector, "_TEMPSTICK_CACHE", cache),
+        ):
+            data = collector.get_tempstick_data()
+
+        assert data is None
+        # Cache stays exactly as it was — no spurious rewrites.
+        assert cache.read_text() == "2026-04-17 15:02:02"
+
+    @patch("requests.get")
+    def test_writes_when_checkin_differs(self, mock_get, tmp_path):
+        """Cache has an older checkin → new reading flows through, cache updated."""
+        cache = tmp_path / "tempstick_last_checkin"
+        cache.write_text("2026-04-17 14:02:02")
+        mock_get.return_value = self._response("2026-04-17 15:02:02", temp=21.5)
+
+        with (
+            patch.object(collector, "TEMP_STICK_API_KEY", "k"),
+            patch.object(collector, "TEMP_STICK_SENSOR_ID", "TS00XXTST1"),
+            patch.object(collector, "_TEMPSTICK_CACHE", cache),
+        ):
+            data = collector.get_tempstick_data()
+
+        assert data is not None
+        assert data["temp"] == 21.5
+        assert cache.read_text() == "2026-04-17 15:02:02"
+
+    @patch("requests.get")
+    def test_missing_checkin_returns_dict_without_touching_cache(self, mock_get, tmp_path):
+        """API 200 without last_checkin (schema drift) → still return dict but
+        leave the cache untouched so an empty-string value can't starve all
+        subsequent calls."""
+        cache = tmp_path / "tempstick_last_checkin"
+        cache.write_text("2026-04-17 14:02:02")
+
+        r = MagicMock()
+        r.status_code = 200
+        # last_checkin absent from the payload
+        r.json.return_value = {"data": {"last_temp": 20.0, "last_humidity": 40.0}}
+        mock_get.return_value = r
+
+        with (
+            patch.object(collector, "TEMP_STICK_API_KEY", "k"),
+            patch.object(collector, "TEMP_STICK_SENSOR_ID", "TS00XXTST1"),
+            patch.object(collector, "_TEMPSTICK_CACHE", cache),
+        ):
+            data = collector.get_tempstick_data()
+
+        assert data is not None
+        assert data["temp"] == 20.0
+        # Cache preserved — no partial state that would poison the next cycle.
+        assert cache.read_text() == "2026-04-17 14:02:02"
+
+    @patch("requests.get")
+    def test_corrupt_cache_self_heals(self, mock_get, tmp_path):
+        """Garbage bytes in the cache (torn write) → treated as 'no prior state',
+        one duplicate row this cycle, cache re-seeded."""
+        cache = tmp_path / "tempstick_last_checkin"
+        cache.write_bytes(b"\x00\xff\x00partial-write")
+        mock_get.return_value = self._response("2026-04-17 15:02:02")
+
+        with (
+            patch.object(collector, "TEMP_STICK_API_KEY", "k"),
+            patch.object(collector, "TEMP_STICK_SENSOR_ID", "TS00XXTST1"),
+            patch.object(collector, "_TEMPSTICK_CACHE", cache),
+        ):
+            data = collector.get_tempstick_data()
+
+        # read_text on the corrupt bytes may raise — _read_tempstick_cache
+        # should handle that gracefully and treat it as cache-miss.
+        assert data is not None
+        assert cache.read_text() == "2026-04-17 15:02:02"
+
+    @patch("requests.get")
+    def test_api_429_does_not_touch_cache(self, mock_get, tmp_path):
+        """429 from the edge WAF → return None immediately; never read or write
+        the cache (transient failure shouldn't corrupt state)."""
+        cache = tmp_path / "tempstick_last_checkin"
+        cache.write_text("2026-04-17 14:02:02")
+
+        r = MagicMock()
+        r.status_code = 429
+        r.text = "Too Many Requests"
+        mock_get.return_value = r
+
+        with (
+            patch.object(collector, "TEMP_STICK_API_KEY", "k"),
+            patch.object(collector, "TEMP_STICK_SENSOR_ID", "TS00XXTST1"),
+            patch.object(collector, "_TEMPSTICK_CACHE", cache),
+        ):
+            data = collector.get_tempstick_data()
+
+        assert data is None
+        assert cache.read_text() == "2026-04-17 14:02:02"
+
+
 class TestEfficiencyEdgeCases:
     """Test edge cases in efficiency calculation"""
 


### PR DESCRIPTION
## Summary

Closes #26. Phase 1b of the four-issue monitoring sprint (plan: [docs/plans/2026-04-17-001-fix-monitoring-sprint-plan.md](../blob/main/docs/plans/2026-04-17-001-fix-monitoring-sprint-plan.md)).

One function touched: `get_tempstick_data()`. The collector reads the API response's `last_checkin` timestamp and compares against `.cache/tempstick_last_checkin`. If unchanged, returns `None` and the caller skips the Sheet write. No other collector paths modified.

## Why

Temp Stick only produces a fresh reading every ~1 hour (battery conservation). The collector runs every 5 minutes, so 11 of every 12 attic rows are identical duplicates — ~264 redundant Sheet writes per day and ~264 redundant API calls. Harmless for analysis (medians don't care about duplicates), but:

1. The Sheet's true per-sensor cadence gets masked — this is one of the reasons #25's data-gap check silently missed the 3-day attic outage (scan window looked fine when attic was "writing" 288 rows/day of stale data).
2. Future WAF tightening at Temp Stick's edge could 429-block us again on the volume alone.

Expected after merge + DGX pull: attic row count drops from ~288/day to ~24/day.

## Safety features (per the deepened plan's adversarial review)

- **Atomic write**: `.tmp` + `os.replace` — SIGTERM during systemd shutdown can't leave a torn partial write.
- **Broad read-error handling** (`OSError`, `UnicodeDecodeError`, `ValueError`): corrupt caches degrade to "no prior state" and self-heal on next successful run. Never starves the Sheet.
- **Missing `last_checkin`** (API schema drift) falls through to the write path WITHOUT touching the cache — prevents empty-string state from poisoning every future call.
- **Cache-write failures** are non-fatal: stderr warning + return dict. One duplicate row is always preferable to a dropped reading.
- **429 / transient failures** never touch the cache. State stays clean across wave-off periods.

## Test plan

- [x] `uv run ruff check .` — clean
- [x] `uv run ruff format --check .` — clean (23 files)
- [x] `uv run pytest -q` — **33 passed** (27 existing + 6 new `TestTempStickDedup`)
  - first-call cache write
  - skip when `last_checkin` unchanged
  - write when `last_checkin` differs
  - missing-`last_checkin` schema drift (cache preserved)
  - corrupt-cache self-healing
  - 429 preserves cache state
- [ ] **Post-merge**: pull on DGX. After 24 hours, confirm attic row count in the Sheet is 20-30/day (not 288).

## Next in the sprint

- **Phase 2 (PR 3)**: bundled Apps Script upgrade — per-sensor cadence data-gap check + `checkIndoorBaseline` absolute threshold alert (closes #25 and #27). Held until 24h post-merge so the Sheet reflects honest cadence before the new monitor is tested against it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)