### PR TITLE
chore(release): prepare for v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-04-17
+
 ### Added
 - **`checkIndoorBaseline` — NEW Apps Script alert** (#32, closes #27). Fires when master-bedroom `Indoor_PM25` sustains above 5 µg/m³ while outdoor is calm (< 10 µg/m³ gate). Option C discrimination: WARNING at 30-min sustained (with slope gate to suppress cooking's decay phase) + CRITICAL at 90-min sustained (regardless of slope). Distinct cooldowns per tier. Backtested against 9 months of data: **1.38 alerts/wk** (0.40 WARN + 0.98 CRIT), down from 6.89/wk at the original threshold=3 proposal.
 - **`MONITOR_VERSION` constant + per-`runAllChecks()` logging** (#32) — deploy-drift between repo and the paste-in-Apps-Script deployment is now grep-able in the execution log, not a mystery.
@@ -214,7 +216,8 @@ Analysis of 82,791 readings revealed:
 - Health correlation tracking capabilities
 - 5-minute automated data collection via cron
 
-[Unreleased]: https://github.com/minghsuy/hvac-air-quality-analysis/compare/v0.5.0...HEAD
+[Unreleased]: https://github.com/minghsuy/hvac-air-quality-analysis/compare/v0.6.0...HEAD
+[0.6.0]: https://github.com/minghsuy/hvac-air-quality-analysis/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/minghsuy/hvac-air-quality-analysis/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/minghsuy/hvac-air-quality-analysis/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/minghsuy/hvac-air-quality-analysis/compare/v0.2.0...v0.3.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hvac-air-quality"
-version = "0.6.0-dev"
+version = "0.6.0"
 description = "Track HVAC filter efficiency to prevent asthma triggers"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -750,7 +750,7 @@ wheels = [
 
 [[package]]
 name = "hvac-air-quality"
-version = "0.6.0.dev0"
+version = "0.6.0"
 source = { virtual = "." }
 dependencies = [
     { name = "google-api-python-client" },


### PR DESCRIPTION
## Release v0.6.0

Version bump + CHANGELOG restructure for the four-issue monitoring sprint release.

### Diff summary

- `pyproject.toml`: `0.6.0-dev` → `0.6.0`
- `uv.lock`: re-locked (version string only; no dep changes)
- `CHANGELOG.md`: rename `[Unreleased]` → `[0.6.0] - 2026-04-17`, add fresh empty `[Unreleased]` above, update version-compare links at bottom

### What's in v0.6.0

All four sprint issues closed:

- **#28** — shared `scripts/_sheets_loader.py` with date-gated shift repair; retroactive recovery of 15,775 attic temp/humidity rows
- **#26** — Temp Stick polling dedups by `last_checkin` (attic writes 288/day → ~24/day)
- **#27** — new `checkIndoorBaseline` alert with Option C discrimination (slope gate + progressive escalation + outdoor gate); 9-month backtest projects 1.38 alerts/wk
- **#25** — `checkDataCollection` rewrite: time-window scan + per-sensor `maxGapHours`
- Plus: #22, #23, #24 from earlier this week (Title 24 claim drop, repo tidy-pass, Temp Stick UA fix)

### Test plan

- [x] `uv run ruff check .` — clean
- [x] `uv run ruff format --check .` — clean (23 files)
- [x] `uv run pytest -q` — 33 passed
- [x] CHANGELOG section + links reviewed for correctness

### After merge

1. Tag `v0.6.0` locally and push (triggers release workflow)
2. Bump `pyproject.toml` to `0.6.1-dev` in a follow-up PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)