### PR TITLE
chore: bump version to 0.6.1-dev

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hvac-air-quality"
-version = "0.6.0"
+version = "0.6.1-dev"
 description = "Track HVAC filter efficiency to prevent asthma triggers"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -750,7 +750,7 @@ wheels = [
 
 [[package]]
 name = "hvac-air-quality"
-version = "0.6.0"
+version = "0.6.1.dev0"
 source = { virtual = "." }
 dependencies = [
     { name = "google-api-python-client" },


### PR DESCRIPTION
Post-release dev-version bump following v0.6.0.

- `pyproject.toml`: `0.6.0` → `0.6.1-dev`
- `uv.lock`: re-locked (version string only)

No other changes. Standard post-release bookkeeping per `CLAUDE.md`.

v0.6.0 release: https://github.com/minghsuy/hvac-air-quality-analysis/releases/tag/v0.6.0