### PR TITLE
ci: auto-trigger Claude review on PR open

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,19 +1,28 @@
-name: Claude Code Review (on-demand)
+name: Claude Code Review
 
-# On-demand PR review. Trigger with an "@claude-review" mention in any PR comment.
-# This complements claude.yml (generic @claude handler) — use @claude-review
-# when you want the structured review rubric below.
+# Auto-fires on PR open / ready_for_review.
+# Manual re-trigger after addressing feedback: comment "@claude-review" on the PR.
+# Skips drafts and bot-authored PRs by design.
 
 on:
+  pull_request:
+    types: [opened, ready_for_review]
   issue_comment:
     types: [created]
 
+concurrency:
+  group: claude-review-${{ github.event.pull_request.number || github.event.issue.number }}
+  cancel-in-progress: true
+
 jobs:
   claude-review:
-    # Only run when someone mentions @claude-review on a PR (not a plain issue).
     if: |
-      github.event.issue.pull_request != null &&
-      contains(github.event.comment.body, '@claude-review')
+      (github.event_name == 'pull_request' &&
+        github.event.pull_request.draft == false &&
+        github.event.pull_request.user.type != 'Bot') ||
+      (github.event_name == 'issue_comment' &&
+        github.event.issue.pull_request != null &&
+        contains(github.event.comment.body, '@claude-review'))
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -21,6 +30,9 @@ jobs:
       issues: write
       id-token: write
       actions: read  # lets Claude check CI status when deciding severity
+
+    env:
+      PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
 
     steps:
       - name: Checkout repository
@@ -39,8 +51,7 @@ jobs:
             --model claude-opus-4-7
             --allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(gh pr checks:*),Bash(gh run view:*),Bash(gh api:*),Bash(git log:*),Bash(git show:*),Bash(git diff:*),Bash(cat:*),Bash(ls:*)"
           prompt: |
-            Review PR #${{ github.event.issue.number }} in ${{ github.repository }}.
-            The author requested this review by commenting @claude-review.
+            Review PR #${{ env.PR_NUMBER }} in ${{ github.repository }}.
 
             # Your goal
             High signal-to-noise. The author is a senior data scientist with 12+
@@ -51,10 +62,10 @@ jobs:
             # Must-read context BEFORE reviewing (in this order)
             1. `cat CLAUDE.md` — project conventions and NEVER-commit rules
             2. `cat docs/LESSONS_LEARNED.md` — resolved past mistakes. DO NOT re-raise an item listed here unless this PR clearly re-introduces the same problem.
-            3. `gh pr view ${{ github.event.issue.number }} --json title,body,author` — author's stated intent and scope
-            4. `gh pr diff ${{ github.event.issue.number }}` — the actual changes
-            5. `gh api repos/${{ github.repository }}/issues/${{ github.event.issue.number }}/comments` — prior comments on this PR. DO NOT re-raise points the author has already addressed or explicitly rejected with reasoning.
-            6. `gh pr checks ${{ github.event.issue.number }}` — if tests already pass, weigh that in severity decisions.
+            3. `gh pr view ${{ env.PR_NUMBER }} --json title,body,author` — author's stated intent and scope
+            4. `gh pr diff ${{ env.PR_NUMBER }}` — the actual changes
+            5. `gh api repos/${{ github.repository }}/issues/${{ env.PR_NUMBER }}/comments` — prior comments on this PR. DO NOT re-raise points the author has already addressed or explicitly rejected with reasoning.
+            6. `gh pr checks ${{ env.PR_NUMBER }}` — if tests already pass, weigh that in severity decisions.
 
             # What you're looking for (ordered by importance)
             1. **CLAUDE.md violations** — especially NEVER-commit items (IPs, MAC addrs, device serials, personal emails, credentials, hardcoded spreadsheet IDs)
@@ -62,6 +73,7 @@ jobs:
             3. **Breaking API / schema changes** not described in the PR body
             4. **Security issues** — secret exposure, injection vectors, unsafe deserialization
             5. **Silent correctness bugs** — timezone mixing, off-by-one on windows, incorrect aggregation, wrong boundary handling
+            6. **Apps Script-specific risks** when `.gs` files change — silent UrlFetchApp failures, Script Properties size limits (9KB/key, 500KB total), trigger quota, V8 vs Rhino feature drift, missing `muteHttpExceptions`
 
             # What you SHOULD NOT flag (even as SHOULD FIX)
             - **Missing unit tests** — author decides when tests are worth it for utility scripts
@@ -83,7 +95,7 @@ jobs:
             3. **Adversarial reviewer** — what specific scenario breaks this code today? Name it concretely, or don't mention it.
 
             # Output format
-            Post ONE comment via `gh pr comment ${{ github.event.issue.number }} --body "..."`. Structure:
+            Post ONE comment via `gh pr comment ${{ env.PR_NUMBER }} --body "..."`. Structure:
             - **Verdict (1 line):** approve / request changes / needs discussion
             - **:red_circle: BLOCKING** — only if any, else omit the section entirely
             - **:yellow_circle: SHOULD FIX** — only if any, else omit


### PR DESCRIPTION
## Why

Both Claude review workflows in this repo are on-demand only — they wait for an `@claude-review` (or `@claude`) comment. PR #36 (the pressure cache fix) never got an auto-review for that reason. For a single-dev repo with the OAuth token already configured, auto-trigger is the better default.

## What changed

`.github/workflows/claude-code-review.yml`:

- **Adds `pull_request: [opened, ready_for_review]` trigger** alongside the existing `issue_comment` path. Manual `@claude-review` mention still works for re-review after addressing feedback (the realistic path once iteration starts — running on every `synchronize` would be noisy and expensive).
- **Skips drafts and bot-authored PRs** via the conditional (`pull_request.draft == false`, `user.type != 'Bot'`).
- **Adds `concurrency` group** keyed by PR number so `@claude-review` re-triggers cancel any in-flight run on the same PR.
- **Single `PR_NUMBER` env var** unifies the two event paths inside the prompt — cleaner than juggling `github.event.issue.number` vs `github.event.pull_request.number`.
- **Adds Apps Script-specific risk category** to the reviewer rubric (silent `UrlFetchApp` failures, Script Properties size limits, V8 feature drift). This repo's primary deploy target is `.gs`, so reviewer should know to flag those.

## Failure modes considered

- **Self-review chicken-and-egg.** This PR is opened against `main` *before* the workflow change merges, so the new auto-trigger won't fire on this PR itself. That's fine — manually `@claude-review` to test, or merge first then test on the next PR.
- **Cost / quota blow-up.** Triggering on `synchronize` would re-review on every push during iteration. Deliberately excluded — only `opened` and `ready_for_review` auto-fire. The `@claude-review` mention covers re-review.
- **Bot PR loops.** `user.type != 'Bot'` skips dependabot/renovate. If a bot ever needs a review, drop a manual `@claude-review`.
- **Stuck concurrent runs.** `concurrency.cancel-in-progress: true` prevents pile-up if a PR is rapidly updated.
- **Workflow itself broken.** YAML is syntax-valid (`yaml.safe_load` parses cleanly). The expression `github.event.pull_request.number || github.event.issue.number` resolves correctly in both event contexts.

## Out of scope

- **`.gs` syntax check in CI.** PR #36's test plan is manual Apps Script paste-and-run — CI can't paste into the editor. The closest CI-feasible guard is `cp HVACMonitor_v3.gs /tmp/x.js && node --check /tmp/x.js` to catch typos before deploy. Happy to add as a follow-up if useful, but kept out of this PR for scope.
- **`claude.yml` (generic `@claude` handler).** Untouched. Still does what it did. Different use case (chat-with-Claude on issues/comments), no need to auto-trigger.

## Test plan

- [x] YAML parses (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [ ] Merge this PR, then verify the next opened PR auto-triggers a review comment
- [ ] Verify `@claude-review` on an existing PR still works (manual re-review path)
- [ ] Verify a draft PR does NOT trigger (mark this PR draft → ready to test if desired)