### PR TITLE
ci: Apps Script (.gs) syntax check

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,21 @@ jobs:
     - name: Run tests
       run: |
         uv run pytest tests/
-        
+
+    # Apps Script (.gs) is V8 JavaScript. Node syntax-checks it cleanly after
+    # a rename — catches typos and broken parens before paste-into-editor deploys.
+    # Ubuntu-only because node is preinstalled and the check is OS-independent.
+    - name: Apps Script syntax check
+      if: matrix.os == 'ubuntu-latest'
+      run: |
+        for gs in $(find . -name '*.gs' -not -path './.git/*' -not -path './.venv/*'); do
+          tmp=$(mktemp --suffix=.js)
+          cp "$gs" "$tmp"
+          node --check "$tmp" || { echo "Syntax error in $gs"; exit 1; }
+          rm "$tmp"
+          echo "OK: $gs"
+        done
+
     # Coverage disabled until package structure is implemented
     # - name: Upload coverage
     #   uses: codecov/codecov-action@v4


### PR DESCRIPTION
## Why

Apps Script files are V8 JavaScript, but the `.gs` extension means no Python tool in our CI catches them. A typo in `HVACMonitor_v3.gs` would slip past ruff/pytest and only surface at deploy time — i.e., after we'd already pasted into the Apps Script editor and hit Run. PR #36's test plan is intrinsically manual for the same reason. This adds the closest CI-feasible guard.

## What

`.github/workflows/test.yml` gains one ubuntu-only step that:

1. Finds every `.gs` file in the repo (currently just `HVACMonitor_v3.gs`).
2. Copies each to a `.js` temp path.
3. Runs `node --check` on it.

`node --check` is parser-only — it won't catch runtime errors or Apps Script API mismatches, but it does catch broken parens, typos, missing commas, and the kind of mistake a copy-paste workflow is most prone to.

## Failure modes considered

- **Node not available.** Preinstalled on `ubuntu-latest` runners, no setup needed. Verified.
- **macOS mktemp differs from GNU.** Step is gated to ubuntu so the GNU `--suffix=.js` form is safe.
- **`.gs` files in `.venv/` or other ignored dirs.** Loop excludes `.git` and `.venv`.
- **Apps Script-specific syntax that V8 rejects.** None known — `.gs` is V8 since the 2020 Rhino sunset. If a future Apps Script feature lands that V8 doesn't have, this step would produce a false positive and we'd revisit.
- **Step runs 2× across matrix.** Avoided via `if: matrix.os == 'ubuntu-latest'` — single check, ~1 second.

## Out of scope

- Linting `.gs` files for style. Apps Script has no canonical linter and ESLint setup would be heavier than this is worth for one file.
- Faking the manual test plan (paste-into-editor → run → inspect Script Properties). That requires Apps Script API access this repo doesn't have.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(...)"` parses
- [x] Loop runs locally and reports `OK: ./HVACMonitor_v3.gs`
- [ ] CI green on this PR (will verify once the workflow runs)
- [ ] Future-proof: introduce a deliberate syntax error on a throwaway branch and confirm the step fails

Stacks cleanly with #37 (Claude review auto-trigger). Either order of merge works.